### PR TITLE
[LARAI] Fix text editor folding in Main lara file

### DIFF
--- a/LARAI/src/org/lara/interpreter/joptions/panels/editor/listeners/EditorListener.java
+++ b/LARAI/src/org/lara/interpreter/joptions/panels/editor/listeners/EditorListener.java
@@ -106,7 +106,8 @@ public class EditorListener {
 	public void changedUpdate(DocumentEvent e) {
 
 	    if (!tab.getOriginalText().equals(tab.getTextArea().getText())) {
-
+	        // when the text area changes, reparse the folds
+	        tab.getTextArea().getFoldManager().reparse();
 		if (!tab.isChanged()) {
 		    tab.getTabbedParent().setChanged(tab);
 		    tab.setChanged(true);

--- a/LARAI/src/org/lara/interpreter/joptions/panels/editor/listeners/EditorListener.java
+++ b/LARAI/src/org/lara/interpreter/joptions/panels/editor/listeners/EditorListener.java
@@ -105,19 +105,19 @@ public class EditorListener {
 	@Override
 	public void changedUpdate(DocumentEvent e) {
 
-	    if (!tab.getOriginalText().equals(tab.getTextArea().getText())) {
-	        // when the text area changes, reparse the folds
-	        tab.getTextArea().getFoldManager().reparse();
-		if (!tab.isChanged()) {
-		    tab.getTabbedParent().setChanged(tab);
-		    tab.setChanged(true);
-		}
-	    } else {
-		if (tab.isChanged()) {
-		    tab.getTabbedParent().setTabTitle(tab);
-		    tab.setChanged(false);
-		}
-	    }
+        if (!tab.getOriginalText().equals(tab.getTextArea().getText())) {
+            // when the text area changes, reparse the folds
+            tab.getTextArea().getFoldManager().reparse();
+            if (!tab.isChanged()) {
+                tab.getTabbedParent().setChanged(tab);
+                tab.setChanged(true);
+            }
+        } else {
+            if (tab.isChanged()) {
+                tab.getTabbedParent().setTabTitle(tab);
+                tab.setChanged(false);
+            }
+        }
 	}
 
 	@Override

--- a/LARAI/src/org/lara/interpreter/joptions/panels/editor/tabbed/MainLaraTab.java
+++ b/LARAI/src/org/lara/interpreter/joptions/panels/editor/tabbed/MainLaraTab.java
@@ -33,13 +33,10 @@ public class MainLaraTab extends SourceTextArea {
 
     public MainLaraTab(TabsContainerPanel parent) {
         super(parent);
-        EditorConfigurer.setLaraTextArea(this);// getTextArea());
-        // getTextArea().addParser(new EditorParser());
     }
 
     public MainLaraTab(File file, TabsContainerPanel parent) {
         super(file, parent);
-        // getTextArea().addParser(new EditorParser());
     }
 
     public boolean open() {


### PR DESCRIPTION
Closes #3 

Besides fixing the folds in the main Lara file, I also made a small tweak to reparse the folds whenever the document changes. I am a bit concerned this might result in a performance penalty for large documents because parsing the folds iterates over each line and every single token. Repeating that on each keystroke could be bad... I thought of a few alternatives:
- Parse the folds on file save event. Should be good enough
- Implement a timing mechanism where the update only happens when the text is not edited for some N milliseconds. This is a common approach for example in searching forms in web applications that perform API requests. Triggering a request per keystroke impacts performance due to re-rendering, but could also impact the server-side with a flood of requests. So only when the user stops typing for a small interval, the request is triggered.

Although the second option seems more elegant, maybe would be slightly more complicated (not much experience with events and timers in Java..). Is it really worth it?!