### PR TITLE
ref(LaraApi): New Pass API

### DIFF
--- a/LaraApi/src-lara/lara/pass/AggregatePassResult.js
+++ b/LaraApi/src-lara/lara/pass/AggregatePassResult.js
@@ -1,0 +1,65 @@
+class AgregatePassResult {
+  /**
+   * Pass this result came from
+   * @type {Pass}
+   */
+  #pass;
+
+  /**
+   * Number of joinpoints that matched the pass predicate.
+   * @type {number}
+   */
+  #casesFound;
+
+  /**
+   * Number of joinpoints where the pass transformation was applied successfully.
+   * @type {number}
+   */
+  #casesApplied;
+
+  /**
+   * Errors thrown where the pass transformation failed.
+   * @type {readonly PassTransformationError[]}
+   */
+  #transformationErrors;
+
+  /**
+   * Whether literal code was inserted during the pass. If so, a rebuild of the AST might be required after the pass.
+   * @type {boolean}
+   */
+  #insertedLiteralCode;
+
+  constructor({
+    pass,
+    casesFound,
+    casesApplied,
+    transformationErrors,
+    insertedLiteralCode,
+  }) {
+    this.#pass = pass;
+    this.#casesFound = casesFound;
+    this.#casesApplied = casesApplied;
+    this.#transformationErrors = Object.freeze([...transformationErrors]);
+    this.#insertedLiteralCode = insertedLiteralCode;
+  }
+
+  get pass() {
+    return this.#pass;
+  }
+
+  get casesFound() {
+    return this.#casesFound;
+  }
+
+  get casesApplied() {
+    return this.#casesApplied;
+  }
+
+  get transformationErrors() {
+    return this.#transformationErrors;
+  }
+
+  get insertedLiteralCode() {
+    return this.#insertedLiteralCode;
+  }
+}

--- a/LaraApi/src-lara/lara/pass/Pass.js
+++ b/LaraApi/src-lara/lara/pass/Pass.js
@@ -1,5 +1,6 @@
 laraImport("weaver.Query");
 laraImport("lara.pass.PassResult");
+laraImport("lara.util.AbstractClassError");
 
 /**
  * Represents a Lara transformation pass.

--- a/LaraApi/src-lara/lara/pass/Pass.js
+++ b/LaraApi/src-lara/lara/pass/Pass.js
@@ -19,12 +19,13 @@ class Pass {
   }
 
   get name() {
-    return this.#name;
+    return this.constructor.name;
   }
 
-  set name(name) {
-    this.#name = name;
-  }
+  /**
+   * @deprecated Automatically infered
+   */
+  set name(_name) {}
 
   /**
    * Applies this pass starting at the given join point. If no join point is given, uses the root join point.

--- a/LaraApi/src-lara/lara/pass/PassTransformationError.js
+++ b/LaraApi/src-lara/lara/pass/PassTransformationError.js
@@ -1,0 +1,40 @@
+class PassTransformationError extends Error {
+  name = "PassTransformationError";
+
+  /**
+   * Joinpoint where the transformation was applied and failed.
+   * @type {$joinpoint}
+   */
+  #joinpoint;
+
+  /**
+   * Message describing the error that occurred.
+   * @type {string}
+   */
+  #description;
+
+  /**
+   * Pass that was being applied when the error was emitted.
+   * @type {Pass}
+   */
+  #pass;
+
+  constructor({ pass, $joinpoint, description }) {
+    this.#description = description;
+    this.#joinpoint = $joinpoint;
+    this.#pass = pass;
+    super(`${$joinpoint.location}: ${description}`);
+  }
+
+  get description() {
+    return this.#description;
+  }
+
+  get $joinpoint() {
+    return this.#joinpoint;
+  }
+
+  get pass() {
+    return this.#pass;
+  }
+}

--- a/LaraApi/src-lara/lara/pass/PassTransformationResult.js
+++ b/LaraApi/src-lara/lara/pass/PassTransformationResult.js
@@ -1,0 +1,37 @@
+class PassTransformationResult {
+  /**
+   * Pass this result came from
+   * @type {Pass}
+   */
+  #pass;
+
+  /**
+   * Joinpoint this transformation was applied to
+   * @type {$joinpoint}
+   */
+  #joinpoint;
+
+  /**
+   * Whether literal code was inserted
+   * @type {boolean}
+   */
+  #insertedLiteralCode;
+
+  constructor({ pass, $joinpoint, insertedLiteralCode }) {
+    this.#pass = pass;
+    this.#joinpoint = $joinpoint;
+    this.insertedLiteralCode = insertedLiteralCode;
+  }
+
+  get pass() {
+    return this.#pass;
+  }
+
+  get $joinpoint() {
+    return this.#joinpoint;
+  }
+
+  get insertedLiteralCode() {
+    return this.#insertedLiteralCode;
+  }
+}


### PR DESCRIPTION
Add new abstract API surface to lara.pass.Pass:

 - `matchJoinpoint($jp) : boolean`: predicate to match joinpoints to be transformed in the pass
 - `transformJoinpoint($jp): PassTransformationResult`: transformation for individual joinpoint

Old abstract `_apply_impl` is still supported temporarily, will be removed once the passes already implemented transition to the new API. 