### PR TITLE
Update Query API to accept wrapper classes as filters

### DIFF
--- a/LARAI/src/org/lara/interpreter/weaver/MasterWeaver.java
+++ b/LARAI/src/org/lara/interpreter/weaver/MasterWeaver.java
@@ -136,11 +136,10 @@ public class MasterWeaver {
             setActions(weaverEngine.getActions());
             setRoot(weaverEngine.getRoot());
             weaverEngine.getWeaverProfiler().reset();
-            List<Class<?>> allImportableClasses = weaverEngine.getAllImportableClasses();
-            
-            if(larai.getWeaverArgs().get(LaraiKeys.API_AUTOLOAD)) {
-                allImportableClasses
-                    .forEach(larai.getInterpreter().getImportProcessor()::importClassWithSimpleName);
+
+            if (larai.getWeaverArgs().get(LaraiKeys.API_AUTOLOAD)) {
+                weaverEngine.getAllImportableClasses()
+                        .forEach(larai.getInterpreter().getImportProcessor()::importClassWithSimpleName);
             }
             
             final List<AGear> gears = weaverEngine.getGears();

--- a/Lara-JS/scripts/build-LaraJoinPoint.js
+++ b/Lara-JS/scripts/build-LaraJoinPoint.js
@@ -61,6 +61,15 @@ export type DefaultAttribute<T extends typeof LaraJoinPoint> = DefaultAttributeH
   T,
   ExtractedType<T["_defaultAttributeInfo"]["map"]>,
   ExtractedType<T["_defaultAttributeInfo"]["type"]>
+>;
+
+type NameFromWrapperClassHelper<T extends typeof LaraJoinPoint, U> = {
+  [K in keyof U]: Equals<T, U[K], K, never>;
+}[keyof U];
+
+export type NameFromWrapperClass<T extends typeof LaraJoinPoint> = NameFromWrapperClassHelper<
+  T,
+  ExtractedType<T["_defaultAttributeInfo"]["jpMapper"]>
 >;\n\n`
   );
 

--- a/Lara-JS/scripts/build-LaraJoinPoint.js
+++ b/Lara-JS/scripts/build-LaraJoinPoint.js
@@ -31,7 +31,37 @@ function buildLaraJoinPoint(inputFileName, outputFileName) {
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-duplicate-type-constituents */
 
-import JavaTypes from "./lara/util/JavaTypes.js";\n\n`
+import JavaTypes from "./lara/util/JavaTypes.js";
+
+/**
+ * Type for type equality assertion. If T is equal to U, return Y, otherwise return N.
+ * Source: https://github.com/Microsoft/TypeScript/issues/27024#issuecomment-421529650
+ * @example
+ * type A = Equals<string, string, "Y", "N">; // "Y"
+ * type B = Equals<string, number, "Y", "N">; // "N"
+ */
+type Equals<T, U, Y = unknown, N = never> =
+  (<G>() => G extends T ? 1 : 2) extends
+  (<G>() => G extends U ? 1 : 2) ? Y : N;
+
+type DefaultAttributeHelper<
+  T extends typeof LaraJoinPoint,
+  DefaultAttributeMap,
+  PrivateMapper,
+> = {
+  [K in keyof DefaultAttributeMap]: K extends keyof PrivateMapper
+    ? Equals<T, PrivateMapper[K], DefaultAttributeMap[K], never>
+    : never;
+}[keyof DefaultAttributeMap];
+
+// Extract the type A from A | undefined
+type ExtractedType<T> = T extends undefined ? never : T;
+
+export type DefaultAttribute<T extends typeof LaraJoinPoint> = DefaultAttributeHelper<
+  T,
+  ExtractedType<T["_defaultAttributeInfo"]["map"]>,
+  ExtractedType<T["_defaultAttributeInfo"]["type"]>
+>;\n\n`
   );
 
   generateJoinpoints(specification.joinpoints, outputFile);
@@ -57,8 +87,8 @@ const JoinpointMappers: JoinpointMapperType[] = [];\n`
   );
 
   fs.writeSync(
-      outputFile,
-      `\n/**
+    outputFile,
+    `\n/**
  * This function is for internal use only. DO NOT USE IT!
  */
 export function clearJoinpointMappers(): void {

--- a/Lara-JS/scripts/build-LaraJoinPoint.js
+++ b/Lara-JS/scripts/build-LaraJoinPoint.js
@@ -57,12 +57,19 @@ const JoinpointMappers: JoinpointMapperType[] = [];\n`
   );
 
   fs.writeSync(
-    outputFile,
-    `\n/**
+      outputFile,
+      `\n/**
  * This function is for internal use only. DO NOT USE IT!
  */
 export function clearJoinpointMappers(): void {
   JoinpointMappers.length = 0;
+}
+
+/**
+ * This function is for internal use only. DO NOT USE IT!
+ */
+export function getJoinpointMappers(): JoinpointMapperType[] {
+  return JoinpointMappers;
 }\n`
   );
 

--- a/Lara-JS/scripts/build-interfaces.js
+++ b/Lara-JS/scripts/build-interfaces.js
@@ -79,7 +79,7 @@ import {
 }
 
 function generateJoinpointMappers(joinpoints, enums, outputFile) {
-  fs.writeSync(outputFile, `const JoinpointMapper: JoinpointMapperType = {\n`);
+  fs.writeSync(outputFile, `const JoinpointMapper = {\n`);
   for (const jp of joinpoints) {
     fs.writeSync(outputFile, `  ${jp.originalName}: ${jp.name},\n`);
   }

--- a/Lara-JS/scripts/build-interfaces.js
+++ b/Lara-JS/scripts/build-interfaces.js
@@ -64,15 +64,21 @@ import {
 } from "lara-js/api/LaraJoinPoint.js";\n\n`
   );
 
+  generateDefaultAttributeMappers(specification.joinpoints, outputFile);
+
   generateJoinpoints(specification.joinpoints, outputFile);
   generateEnums(specification.enums, outputFile);
 
-  generateMappers(specification.joinpoints, specification.enums, outputFile);
+  generateJoinpointMappers(
+    specification.joinpoints,
+    specification.enums,
+    outputFile
+  );
 
   fs.closeSync(outputFile);
 }
 
-function generateMappers(joinpoints, enums, outputFile) {
+function generateJoinpointMappers(joinpoints, enums, outputFile) {
   fs.writeSync(outputFile, `const JoinpointMapper: JoinpointMapperType = {\n`);
   for (const jp of joinpoints) {
     fs.writeSync(outputFile, `  ${jp.originalName}: ${jp.name},\n`);
@@ -85,8 +91,24 @@ function generateMappers(joinpoints, enums, outputFile) {
 if (!registered) {
   registerJoinpointMapper(JoinpointMapper);
   registered = true;
-}\n`
+}\n\n`
   );
+}
+
+function generateDefaultAttributeMappers(joinpoints, outputFile) {
+  fs.writeSync(outputFile, `type PrivateMapper = {\n`);
+  for (const jp of joinpoints) {
+    fs.writeSync(outputFile, `  "${jp.name}": typeof ${jp.name},\n`);
+  }
+  fs.writeSync(outputFile, `};\n\n`);
+
+  fs.writeSync(outputFile, `type DefaultAttributeMap = {\n`);
+  for (const jp of joinpoints) {
+    if (jp.defaultAttribute) {
+      fs.writeSync(outputFile, `  ${jp.name}: "${jp.defaultAttribute}",\n`);
+    }
+  }
+  fs.writeSync(outputFile, `}\n\n`);
 }
 
 const args = yargs(hideBin(process.argv))

--- a/Lara-JS/scripts/convert-joinpoint-specification.js
+++ b/Lara-JS/scripts/convert-joinpoint-specification.js
@@ -305,6 +305,14 @@ function convertJoinpointAction(
         }
 
         action.overloads.push(convertedAction);
+        action.returnType = [...new Set(action.returnType.split(" | "))].join(
+          " | "
+        );
+        for (const i in action.parameters) {
+          action.parameters[i].type = [
+            ...new Set(action.parameters[i].type.split(" | ")),
+          ].join(" | ");
+        }
         break;
       }
     }

--- a/Lara-JS/scripts/generate-ts-joinpoints.js
+++ b/Lara-JS/scripts/generate-ts-joinpoints.js
@@ -17,7 +17,7 @@ function generateJoinpoint(jp, outputFile, joinpoints) {
   if (jp.name === "LaraJoinPoint") {
     fs.writeSync(
       outputFile,
-      "  static readonly _defaultAttributeInfo: {map?: any, name: string | null, type?: any} = {\n" +
+      "  static readonly _defaultAttributeInfo: {readonly map?: any, readonly name: string | null, readonly type?: any, readonly jpMapper?: any} = {\n" +
         `    name: ${jp.defaultAttribute ? '"' + jp.defaultAttribute + '"' : "null"},\n` +
         "  };\n"
     );
@@ -31,7 +31,7 @@ function generateJoinpoint(jp, outputFile, joinpoints) {
   } else {
     fs.writeSync(
       outputFile,
-      "  static readonly _defaultAttributeInfo: {map?: DefaultAttributeMap, name: string | null, type?: PrivateMapper} = {\n" +
+      "  static readonly _defaultAttributeInfo: {readonly map?: DefaultAttributeMap, readonly name: string | null, readonly type?: PrivateMapper, readonly jpMapper?: typeof JoinpointMapper} = {\n" +
         `    name: ${jp.defaultAttribute ? '"' + jp.defaultAttribute + '"' : "null"},\n` +
         "  };\n"
     );

--- a/Lara-JS/scripts/generate-ts-joinpoints.js
+++ b/Lara-JS/scripts/generate-ts-joinpoints.js
@@ -12,16 +12,28 @@ function generateJoinpoint(jp, outputFile, joinpoints) {
     outputFile,
     `${generateDocumentation(jp.tooltip)}export class ${jp.name}${
       jp.extends ? ` extends ${jp.extends}` : ""
-    } {${jp.defaultAttribute ? '\n  static readonly _defaultAttribute: string | null = "' + jp.defaultAttribute + '";' : ""}\n`
+    } {\n`
   );
   if (jp.name === "LaraJoinPoint") {
     fs.writeSync(
       outputFile,
+      "  static readonly _defaultAttributeInfo: {map?: any, name: string | null, type?: any} = {\n" +
+        `    name: ${jp.defaultAttribute ? '"' + jp.defaultAttribute + '"' : "null"},\n` +
+        "  };\n"
+    );
+    fs.writeSync(
+      outputFile,
       `  _javaObject!: any;
-  static readonly _defaultAttribute: string | null = ${jp.defaultAttribute ? `"${jp.defaultAttribute}"` : "null"};
   constructor(obj: any) {
     this._javaObject = obj;
   }\n`
+    );
+  } else {
+    fs.writeSync(
+      outputFile,
+      "  static readonly _defaultAttributeInfo: {map?: DefaultAttributeMap, name: string | null, type?: PrivateMapper} = {\n" +
+        `    name: ${jp.defaultAttribute ? '"' + jp.defaultAttribute + '"' : "null"},\n` +
+        "  };\n"
     );
   }
 

--- a/Lara-JS/src-api/LaraJoinPoint.ts
+++ b/Lara-JS/src-api/LaraJoinPoint.ts
@@ -56,6 +56,13 @@ export function clearJoinpointMappers(): void {
   JoinpointMappers.length = 0;
 }
 
+/**
+ * This function is for internal use only. DO NOT USE IT!
+ */
+export function getJoinpointMappers(): JoinpointMapperType[] {
+  return JoinpointMappers;
+}
+
 export function wrapJoinPoint(obj: any): any {
   if (JoinpointMappers.length === 0) {
     return obj;

--- a/Lara-JS/src-api/LaraJoinPoint.ts
+++ b/Lara-JS/src-api/LaraJoinPoint.ts
@@ -42,8 +42,17 @@ export type DefaultAttribute<T extends typeof LaraJoinPoint> = DefaultAttributeH
   ExtractedType<T["_defaultAttributeInfo"]["type"]>
 >;
 
+type NameFromWrapperClassHelper<T extends typeof LaraJoinPoint, U> = {
+  [K in keyof U]: Equals<T, U[K], K, never>;
+}[keyof U];
+
+export type NameFromWrapperClass<T extends typeof LaraJoinPoint> = NameFromWrapperClassHelper<
+  T,
+  ExtractedType<T["_defaultAttributeInfo"]["jpMapper"]>
+>;
+
 export class LaraJoinPoint {
-  static readonly _defaultAttributeInfo: {map?: any, name: string | null, type?: any} = {
+  static readonly _defaultAttributeInfo: {readonly map?: any, readonly name: string | null, readonly type?: any, readonly jpMapper?: any} = {
     name: null,
   };
   _javaObject!: any;

--- a/Lara-JS/src-api/LaraJoinPoint.ts
+++ b/Lara-JS/src-api/LaraJoinPoint.ts
@@ -12,9 +12,41 @@
 
 import JavaTypes from "./lara/util/JavaTypes.js";
 
+/**
+ * Type for type equality assertion. If T is equal to U, return Y, otherwise return N.
+ * Source: https://github.com/Microsoft/TypeScript/issues/27024#issuecomment-421529650
+ * @example
+ * type A = Equals<string, string, "Y", "N">; // "Y"
+ * type B = Equals<string, number, "Y", "N">; // "N"
+ */
+type Equals<T, U, Y = unknown, N = never> =
+  (<G>() => G extends T ? 1 : 2) extends
+  (<G>() => G extends U ? 1 : 2) ? Y : N;
+
+type DefaultAttributeHelper<
+  T extends typeof LaraJoinPoint,
+  DefaultAttributeMap,
+  PrivateMapper,
+> = {
+  [K in keyof DefaultAttributeMap]: K extends keyof PrivateMapper
+    ? Equals<T, PrivateMapper[K], DefaultAttributeMap[K], never>
+    : never;
+}[keyof DefaultAttributeMap];
+
+// Extract the type A from A | undefined
+type ExtractedType<T> = T extends undefined ? never : T;
+
+export type DefaultAttribute<T extends typeof LaraJoinPoint> = DefaultAttributeHelper<
+  T,
+  ExtractedType<T["_defaultAttributeInfo"]["map"]>,
+  ExtractedType<T["_defaultAttributeInfo"]["type"]>
+>;
+
 export class LaraJoinPoint {
+  static readonly _defaultAttributeInfo: {map?: any, name: string | null, type?: any} = {
+    name: null,
+  };
   _javaObject!: any;
-  static readonly _defaultAttribute: string | null = null;
   constructor(obj: any) {
     this._javaObject = obj;
   }

--- a/Lara-JS/src-api/LaraJoinPoint.ts
+++ b/Lara-JS/src-api/LaraJoinPoint.ts
@@ -63,13 +63,13 @@ export class LaraJoinPoint {
   get scopeNodes(): LaraJoinPoint[] { return wrapJoinPoint(this._javaObject.getScopeNodes()) }
   insert(position: "before" | "after" | "replace", code: string): LaraJoinPoint;
   insert(position: "before" | "after" | "replace", joinpoint: LaraJoinPoint): LaraJoinPoint;
-  insert(p1: "before" | "after" | "replace", p2: string | LaraJoinPoint): LaraJoinPoint | LaraJoinPoint { return wrapJoinPoint(this._javaObject.insert(unwrapJoinPoint(p1), unwrapJoinPoint(p2))); }
+  insert(p1: "before" | "after" | "replace", p2: string | LaraJoinPoint): LaraJoinPoint { return wrapJoinPoint(this._javaObject.insert(unwrapJoinPoint(p1), unwrapJoinPoint(p2))); }
   def(attribute: string, value: object): void { return wrapJoinPoint(this._javaObject.def(unwrapJoinPoint(attribute), unwrapJoinPoint(value))); }
   toString(): string { return wrapJoinPoint(this._javaObject.toString()); }
   equals(jp: LaraJoinPoint): boolean { return wrapJoinPoint(this._javaObject.equals(unwrapJoinPoint(jp))); }
   instanceOf(name: string): boolean;
   instanceOf(names: string[]): boolean;
-  instanceOf(p1: string | string[]): boolean | boolean { return wrapJoinPoint(this._javaObject.instanceOf(unwrapJoinPoint(p1))); }
+  instanceOf(p1: string | string[]): boolean { return wrapJoinPoint(this._javaObject.instanceOf(unwrapJoinPoint(p1))); }
 }
 
 

--- a/Lara-JS/src-api/jest.config.js
+++ b/Lara-JS/src-api/jest.config.js
@@ -1,10 +1,11 @@
 const config = {
   preset: "ts-jest/presets/default-esm",
   testEnvironment: "lara-js/jest/jestEnvironment.js",
-  globalSetup: "lara-js/jest/jestGlobalSetup.js",
-  globalTeardown: "lara-js/jest/jestGlobalTeardown.js",
+  //globalSetup: "lara-js/jest/jestGlobalSetup.js",
+  //globalTeardown: "lara-js/jest/jestGlobalTeardown.js",
   setupFiles: ["lara-js/jest/setupFiles/sharedJavaModule.js"],
   moduleNameMapper: {
+    "lara-js/api/(.+).js": "lara-js/src-api/$1",
     "(.+)\\.js": "$1",
   },
 };

--- a/Lara-JS/src-api/lara/Collections.ts
+++ b/Lara-JS/src-api/lara/Collections.ts
@@ -1,5 +1,5 @@
 import JavaInterop from "./JavaInterop.js";
-import JavaTypes, {JavaClasses} from "./util/JavaTypes.js";
+import JavaTypes, { JavaClasses } from "./util/JavaTypes.js";
 
 /**
  *  Utility methods related to Collections.
@@ -11,7 +11,9 @@ export default class Collections {
    *
    * @returns The sorted collection
    */
-  static sort(values: any[] | JavaClasses.List): any[] | JavaClasses.List {
+  static sort<T>(values: T[]): T[];
+  static sort<T>(values: JavaClasses.List<T>): JavaClasses.List<T>;
+  static sort<T>(values: T[] | JavaClasses.List<T>): T[] | JavaClasses.List<T> {
     // If array
     if (values instanceof Array) {
       values.sort();

--- a/Lara-JS/src-api/lara/JavaInterop.ts
+++ b/Lara-JS/src-api/lara/JavaInterop.ts
@@ -38,6 +38,6 @@ export default class JavaInterop {
    * @deprecated Use JavaTypes instead
    */
   static getClass(classname: string) {
-    return Java.type(classname).class;
+    return JavaTypes.getType(classname).class;
   }
 }

--- a/Lara-JS/src-api/lara/JavaInterop.ts
+++ b/Lara-JS/src-api/lara/JavaInterop.ts
@@ -1,10 +1,10 @@
-import JavaTypes, {JavaClasses} from "./util/JavaTypes.js";
+import JavaTypes, { JavaClasses } from "./util/JavaTypes.js";
 
 export default class JavaInterop {
   /**
    * Converts a JS array into a java.util.List.
    */
-  static arrayToList<T>(array: Array<T>): JavaClasses.List {
+  static arrayToList<T>(array: Array<T>): JavaClasses.List<T> {
     const ArrayListClass = JavaTypes.ArrayList;
     const list = new ArrayListClass();
 

--- a/Lara-JS/src-api/lara/Strings.ts
+++ b/Lara-JS/src-api/lara/Strings.ts
@@ -92,7 +92,7 @@ export default class Strings {
     return undefined;
   }
 
-  static asLines(string?: string): JavaClasses.List | undefined {
+  static asLines(string?: string): JavaClasses.List<string> | undefined {
     if (string === undefined) {
       return undefined;
     }

--- a/Lara-JS/src-api/lara/util/JavaTypes.ts
+++ b/Lara-JS/src-api/lara/util/JavaTypes.ts
@@ -26,7 +26,7 @@ export namespace JavaClasses {
   export interface LaraApiTools extends JavaClass {}
   export interface LaraSystemTools extends JavaClass {
     runCommand(
-      command: string | JavaClasses.List,
+      command: string | JavaClasses.List<string>,
       workingDir: string,
       printToConsole: boolean,
       timeoutNanos?: number
@@ -51,7 +51,9 @@ export namespace JavaClasses {
     getParentFile(): JavaClasses.File;
     getAbsolutePath(): string;
   }
-  export interface List extends JavaClass {}
+  export interface List<T> extends JavaClass {
+    [Symbol.iterator](): IterableIterator<T>;
+  }
   export interface Collections extends JavaClass {}
   export interface Diff extends JavaClass {}
   export interface XStreamUtils extends JavaClass {}
@@ -221,7 +223,7 @@ export default class JavaTypes {
   }
 
   static get List() {
-    return JavaTypes.getType("java.util.List") as JavaClasses.List;
+    return JavaTypes.getType("java.util.List") as JavaClasses.List<any>;
   }
 
   static get Collections() {

--- a/Lara-JS/src-api/lara/util/JpFilter.ts
+++ b/Lara-JS/src-api/lara/util/JpFilter.ts
@@ -4,7 +4,6 @@ import { laraGetter } from "../core/LaraCore.js";
 type JpFilterTypes =
   | RegExp
   | ((str: string, jp?: LaraJoinPoint) => boolean)
-  | ((jp: LaraJoinPoint) => boolean)
   | string
   | boolean
   | number

--- a/Lara-JS/src-api/lara/util/JpFilter.ts
+++ b/Lara-JS/src-api/lara/util/JpFilter.ts
@@ -3,11 +3,12 @@ import { laraGetter } from "../core/LaraCore.js";
 
 type JpFilterTypes =
   | RegExp
-  | ((str: string) => boolean)
+  | ((str: string, jp?: LaraJoinPoint) => boolean)
   | ((jp: LaraJoinPoint) => boolean)
   | string
   | boolean
-  | number;
+  | number
+  | undefined;
 
 export type JpFilterRules = {
   [key: string]: JpFilterTypes;
@@ -60,7 +61,7 @@ export default class JpFilter {
 
   private match(value: any, pattern: JpFilterTypes): boolean {
     if (
-      (pattern instanceof RegExp && pattern.test(value)) ||
+      (pattern instanceof RegExp && pattern.test(value as string)) ||
       (typeof pattern === "function" && pattern(value)) ||
       (typeof pattern === "string" && value === pattern) ||
       (typeof pattern === "boolean" && value === pattern) ||

--- a/Lara-JS/src-api/lara/util/LocalFolder.ts
+++ b/Lara-JS/src-api/lara/util/LocalFolder.ts
@@ -80,7 +80,9 @@ export default class LocalFolder {
   /**
    * @returns A java List with all the files in this LocalFolder
    */
-  getFileList(path?: string | JavaClasses.File): JavaClasses.List {
+  getFileList(
+    path?: string | JavaClasses.File
+  ): JavaClasses.List<JavaClasses.File> {
     let basePath = this.baseFolder;
 
     if (path !== undefined) {

--- a/Lara-JS/src-api/lara/util/ProcessExecutor.ts
+++ b/Lara-JS/src-api/lara/util/ProcessExecutor.ts
@@ -122,7 +122,7 @@ export default class ProcessExecutor {
       timeoutNanos = this.timeUnit.toNanos(this.timeout);
     }
 
-    let javaCommand: string[] | JavaClasses.List = command;
+    let javaCommand: string[] | JavaClasses.List<string> = command;
 
     // If Java command is an array, make sure array list is used
     if (javaCommand instanceof Array) {

--- a/Lara-JS/src-api/weaver/JoinPoints.ts
+++ b/Lara-JS/src-api/weaver/JoinPoints.ts
@@ -80,36 +80,45 @@ export default class JoinPoints {
    *
    * @returns the nodes inside the scope of the given node.
    */
-  static scope($jp: LaraJoinPoint, jpType?: string): LaraJoinPoint[] {
-    return JoinPoints._getNodes(JoinPoints._all_scope_nodes, $jp, jpType);
+  static scope<T extends typeof LaraJoinPoint>(
+    $jp: LaraJoinPoint,
+    jpType?: T
+  ): LaraJoinPoint[] {
+    return JoinPoints._getNodes(JoinPoints._all_scope_nodes($jp), $jp, jpType);
   }
 
   /**
    *
    * @returns the children of the given node, according to the AST
    */
-  static children($jp: LaraJoinPoint, jpType?: string): LaraJoinPoint[] {
-    return JoinPoints._getNodes(JoinPoints._all_children, $jp, jpType);
+  static children<T extends typeof LaraJoinPoint>(
+    $jp: LaraJoinPoint,
+    jpType?: T
+  ): LaraJoinPoint[] {
+    return JoinPoints._getNodes(JoinPoints._all_children($jp), $jp, jpType);
   }
 
   /**
    *
    * @returns the descendants of the given node, according to the AST, preorder traversal
    */
-  static descendants($jp: LaraJoinPoint, jpType?: string): LaraJoinPoint[] {
-    return JoinPoints._getNodes(JoinPoints._all_descendants, $jp, jpType);
+  static descendants<T extends typeof LaraJoinPoint>(
+    $jp: LaraJoinPoint,
+    jpType?: T
+  ): LaraJoinPoint[] {
+    return JoinPoints._getNodes(JoinPoints._all_descendants($jp), $jp, jpType);
   }
 
   /**
    *
    * @returns the descendants of the given node, according to the AST, postorder traversal
    */
-  static descendantsPostorder(
+  static descendantsPostorder<T extends typeof LaraJoinPoint>(
     $jp: LaraJoinPoint,
-    jpType?: string
+    jpType?: T
   ): LaraJoinPoint[] {
     return JoinPoints._getNodes(
-      JoinPoints._all_descendants_postorder,
+      JoinPoints._all_descendants_postorder($jp),
       $jp,
       jpType
     );
@@ -119,25 +128,24 @@ export default class JoinPoints {
    *
    * @returns  the nodes related with the given node, according to the search function
    */
-  static _getNodes(
-    searchFunction: ($jp: LaraJoinPoint) => LaraJoinPoint[],
+  static _getNodes<T extends typeof LaraJoinPoint>(
+    $allJps: LaraJoinPoint[],
     $jp: LaraJoinPoint,
-    jpType?: string
+    jpType?: T
   ): LaraJoinPoint[] {
     // TODO: This function can be optimized by using streaming
-
-    const descendants: LaraJoinPoint[] = searchFunction($jp);
-
     if (jpType === undefined) {
-      return descendants;
+      return $allJps;
     }
 
-    return JoinPoints._filterNodes(descendants ?? [], jpType);
+    return JoinPoints._filterNodes($allJps, jpType);
   }
 
-  static _filterNodes($jps: LaraJoinPoint[], jpType: string) {
-    // TODO: This check should be done with the JS Classes
-    return $jps.filter((jp) => jp.instanceOf(jpType));
+  static _filterNodes<T extends typeof LaraJoinPoint>(
+    $jps: LaraJoinPoint[],
+    jpType: T
+  ) {
+    return $jps.filter((jp) => jp instanceof jpType);
   }
 
   /**

--- a/Lara-JS/src-api/weaver/JoinPoints.ts
+++ b/Lara-JS/src-api/weaver/JoinPoints.ts
@@ -137,7 +137,7 @@ export default class JoinPoints {
 
   static _filterNodes($jps: LaraJoinPoint[], jpType: string) {
     // TODO: This check should be done with the JS Classes
-    return $jps.filter((jp) => (jp as any).instanceOf(jpType));
+    return $jps.filter((jp) => jp.instanceOf(jpType));
   }
 
   /**

--- a/Lara-JS/src-api/weaver/JoinPoints.ts
+++ b/Lara-JS/src-api/weaver/JoinPoints.ts
@@ -18,7 +18,7 @@ export default class JoinPoints {
    *
    */
   static toJoinPoint(node: any): LaraJoinPoint {
-    throw "JoinPoints.toJoinPoint: not implemented";
+    throw new Error("JoinPoints.toJoinPoint: not implemented");
   }
 
   /**
@@ -49,7 +49,9 @@ export default class JoinPoints {
    *
    * @returns all the descendants of the given node, in post order
    */
-  static _all_descendants_postorder($jp: LaraJoinPoint): LaraJoinPoint[] {
+  private static _all_descendants_postorder(
+    $jp: LaraJoinPoint
+  ): LaraJoinPoint[] {
     const descendants: LaraJoinPoint[] = [];
 
     for (const child of JoinPoints._all_children($jp)) {
@@ -60,7 +62,7 @@ export default class JoinPoints {
     return descendants;
   }
 
-  static _all_descendants_postorder_helper(
+  private static _all_descendants_postorder_helper(
     $jp: LaraJoinPoint
   ): LaraJoinPoint[] {
     const nodes: LaraJoinPoint[] = [];
@@ -84,7 +86,7 @@ export default class JoinPoints {
     $jp: LaraJoinPoint,
     jpType?: T
   ): LaraJoinPoint[] {
-    return JoinPoints._getNodes(JoinPoints._all_scope_nodes($jp), $jp, jpType);
+    return JoinPoints._getNodes(jpType, JoinPoints._all_scope_nodes($jp));
   }
 
   /**
@@ -95,7 +97,7 @@ export default class JoinPoints {
     $jp: LaraJoinPoint,
     jpType?: T
   ): LaraJoinPoint[] {
-    return JoinPoints._getNodes(JoinPoints._all_children($jp), $jp, jpType);
+    return JoinPoints._getNodes(jpType, JoinPoints._all_children($jp));
   }
 
   /**
@@ -106,7 +108,7 @@ export default class JoinPoints {
     $jp: LaraJoinPoint,
     jpType?: T
   ): LaraJoinPoint[] {
-    return JoinPoints._getNodes(JoinPoints._all_descendants($jp), $jp, jpType);
+    return JoinPoints._getNodes(jpType, JoinPoints._all_descendants($jp));
   }
 
   /**
@@ -118,9 +120,8 @@ export default class JoinPoints {
     jpType?: T
   ): LaraJoinPoint[] {
     return JoinPoints._getNodes(
-      JoinPoints._all_descendants_postorder($jp),
-      $jp,
-      jpType
+      jpType,
+      JoinPoints._all_descendants_postorder($jp)
     );
   }
 
@@ -128,24 +129,16 @@ export default class JoinPoints {
    *
    * @returns  the nodes related with the given node, according to the search function
    */
-  static _getNodes<T extends typeof LaraJoinPoint>(
-    $allJps: LaraJoinPoint[],
-    $jp: LaraJoinPoint,
-    jpType?: T
+  private static _getNodes<T extends typeof LaraJoinPoint>(
+    jpType?: T,
+    $allJps: LaraJoinPoint[] = []
   ): LaraJoinPoint[] {
     // TODO: This function can be optimized by using streaming
     if (jpType === undefined) {
       return $allJps;
     }
 
-    return JoinPoints._filterNodes($allJps, jpType);
-  }
-
-  static _filterNodes<T extends typeof LaraJoinPoint>(
-    $jps: LaraJoinPoint[],
-    jpType: T
-  ) {
-    return $jps.filter((jp) => jp instanceof jpType);
+    return $allJps.filter((jp) => jp instanceof jpType);
   }
 
   /**

--- a/Lara-JS/src-api/weaver/Query.ts
+++ b/Lara-JS/src-api/weaver/Query.ts
@@ -1,6 +1,9 @@
 import { LaraJoinPoint } from "../LaraJoinPoint.js";
 import JoinPoints from "./JoinPoints.js";
-import Selector, { type JpFilter, type SelectorFilter } from "./Selector.js";
+import Selector, {
+  type Filter_StringVariant,
+  type Filter_WrapperVariant,
+} from "./Selector.js";
 import TraversalType from "./TraversalType.js";
 
 /**
@@ -30,7 +33,7 @@ export default class Query {
    */
   static search<T extends typeof LaraJoinPoint>(
     type: T,
-    filter?: JpFilter<InstanceType<T>> | ((obj: InstanceType<T>) => boolean),
+    filter?: Filter_WrapperVariant<T>,
     traversal?: TraversalType
   ): Selector;
   /**
@@ -46,14 +49,12 @@ export default class Query {
    */
   static search(
     type: string,
-    filter?: SelectorFilter,
+    filter?: Filter_StringVariant,
     traversal?: TraversalType
   ): Selector;
   static search<T extends typeof LaraJoinPoint>(
     type: T | string,
-    filter?:
-      | (JpFilter<InstanceType<T>> | ((obj: InstanceType<T>) => boolean))
-      | SelectorFilter,
+    filter?: Filter_WrapperVariant<T> | Filter_StringVariant,
     traversal: TraversalType = TraversalType.PREORDER
   ): Selector {
     if (typeof type === "string") {
@@ -61,9 +62,7 @@ export default class Query {
     } else {
       return new Selector().search(
         type,
-        filter as
-          | JpFilter<InstanceType<T>>
-          | ((obj: InstanceType<T>) => boolean),
+        filter as Filter_WrapperVariant<T>,
         traversal
       );
     }
@@ -79,13 +78,45 @@ export default class Query {
    *
    * @returns The results of the search.
    */
+  static searchFrom<T extends typeof LaraJoinPoint>(
+    $baseJp: LaraJoinPoint,
+    type?: T,
+    filter?: Filter_WrapperVariant<T>,
+    traversal?: TraversalType
+  ): Selector;
+  /**
+   * In-depth search of nodes of the given type, starting from a base node (exclusive).
+   *
+   * @deprecated Use the new version of this function that receives a class as the first parameter.
+   *
+   * @param $baseJp - starting join point for the search.
+   * @param type - type of the join point to search.
+   * @param filter - filter rules for the search. If the value is an object, each field of the object represents a rule that will be applied over the attribute that has the same name as the name of the field. If the value is not an object (e.g., String, Regex, Lambda), it is interpreted as a single rule that will be applied over the default attribute of the given type. E.g., if type is 'function', the value is a String 'foo' and the default attribute of function is 'name', this is equivalent as passing as value the object \{'name':'foo'\}. Rules can be a String (i.e., will match the value of the attribute against a string), a Regex (will match the value of the attribute against a regex) or a Function (i.e., function receives the value of the attribute and returns true if there is a match, or false otherwise).
+   * @param traversal - AST traversal type, according to weaver.TraversalType
+   *
+   * @returns The results of the search.
+   */
   static searchFrom(
     $baseJp: LaraJoinPoint,
     type?: string,
-    filter?: SelectorFilter,
+    filter?: Filter_StringVariant,
+    traversal?: TraversalType
+  ): Selector;
+  static searchFrom<T extends typeof LaraJoinPoint>(
+    $baseJp: LaraJoinPoint,
+    type?: string,
+    filter?: Filter_WrapperVariant<T> | Filter_StringVariant,
     traversal: TraversalType = TraversalType.PREORDER
   ): Selector {
-    return new Selector($baseJp).search(type, filter, traversal);
+    if (typeof type === "string") {
+      return new Selector($baseJp).search(
+        type,
+        filter as Filter_StringVariant,
+        traversal
+      );
+    } else {
+      return new Selector($baseJp).search(type, filter, traversal);
+    }
   }
 
   /**
@@ -98,13 +129,49 @@ export default class Query {
    *
    * @returns The results of the search.
    */
+  static searchFromInclusive<T extends typeof LaraJoinPoint>(
+    $baseJp: LaraJoinPoint,
+    type?: T,
+    filter?: Filter_WrapperVariant<T>,
+    traversal?: TraversalType
+  ): Selector;
+  /**
+   * The same as Query.searchFrom(), but $baseJp is included in the search.
+   *
+   * @deprecated Use the new version of this function that receives a class as the first parameter.
+   *
+   * @param $baseJp - starting join point for the search.
+   * @param type - type of the join point to search.
+   * @param filter - filter rules for the search.
+   * @param traversal - AST traversal type, according to weaver.TraversalType
+   *
+   * @returns The results of the search.
+   */
   static searchFromInclusive(
     $baseJp: LaraJoinPoint,
     type?: string,
-    filter?: SelectorFilter,
+    filter?: Filter_StringVariant,
+    traversal?: TraversalType
+  ): Selector;
+  static searchFromInclusive<T extends typeof LaraJoinPoint>(
+    $baseJp: LaraJoinPoint,
+    type?: T | string,
+    filter?: Filter_WrapperVariant<T> | Filter_StringVariant,
     traversal: TraversalType = TraversalType.PREORDER
   ): Selector {
-    return new Selector($baseJp, true).search(type, filter, traversal);
+    if (typeof type === "string") {
+      return new Selector($baseJp, true).search(
+        type,
+        filter as Filter_StringVariant,
+        traversal
+      );
+    } else {
+      return new Selector($baseJp, true).search(
+        type,
+        filter as Filter_WrapperVariant<T>,
+        traversal
+      );
+    }
   }
 
   /**
@@ -116,13 +183,43 @@ export default class Query {
    *
    * @returns The results of the search.
    */
+  static childrenFrom<T extends typeof LaraJoinPoint>(
+    $baseJp: LaraJoinPoint,
+    type?: T,
+    filter?: Filter_WrapperVariant<T>
+  ): Selector;
+  /**
+   * Search the direct children of the given $baseJp.
+   *
+   * @deprecated Use the new version of this function that receives a class as the first parameter.
+   *
+   * @param $baseJp - starting join point for the search.
+   * @param type - type of the join point to search.
+   * @param filter - filter rules for the search.
+   *
+   * @returns The results of the search.
+   */
   static childrenFrom(
     $baseJp: LaraJoinPoint,
     type?: string,
-    filter?: SelectorFilter
+    filter?: Filter_StringVariant
+  ): Selector;
+  static childrenFrom<T extends typeof LaraJoinPoint>(
+    $baseJp: LaraJoinPoint,
+    type?: T | string,
+    filter?: Filter_WrapperVariant<T> | Filter_StringVariant
   ): Selector {
-    // These rules will be used to create a lara.util.JpFilter instance, please refer to that class for details on what kinds of rules are supported.
-    return new Selector($baseJp).children(type, filter);
+    if (typeof type === "string") {
+      return new Selector($baseJp).children(
+        type,
+        filter as Filter_StringVariant
+      );
+    } else {
+      return new Selector($baseJp).children(
+        type,
+        filter as Filter_WrapperVariant<T>
+      );
+    }
   }
 
   /**
@@ -134,11 +231,39 @@ export default class Query {
    *
    * @returns The results of the search.
    */
+  static scopeFrom<T extends typeof LaraJoinPoint>(
+    $baseJp: LaraJoinPoint,
+    type?: T,
+    filter?: Filter_WrapperVariant<T>
+  ): Selector;
+  /**
+   * If $baseJp has the concept of scope (e.g. if, loop), search the direct children of that scope.
+   *
+   * @deprecated Use the new version of this function that receives a class as the first parameter.
+   *
+   * @param $baseJp - starting join point for the search.
+   * @param type - type of the join point to search.
+   * @param filter - filter rules for the search.
+   *
+   * @returns The results of the search.
+   */
   static scopeFrom(
     $baseJp: LaraJoinPoint,
     type?: string,
-    filter?: SelectorFilter
+    filter?: Filter_StringVariant
+  ): Selector;
+  static scopeFrom<T extends typeof LaraJoinPoint>(
+    $baseJp: LaraJoinPoint,
+    type?: T | string,
+    filter?: Filter_WrapperVariant<T> | Filter_StringVariant
   ): Selector {
-    return new Selector($baseJp).scope(type, filter);
+    if (typeof type === "string") {
+      return new Selector($baseJp).scope(type, filter as Filter_StringVariant);
+    } else {
+      return new Selector($baseJp).scope(
+        type,
+        filter as Filter_WrapperVariant<T>
+      );
+    }
   }
 }

--- a/Lara-JS/src-api/weaver/Query.ts
+++ b/Lara-JS/src-api/weaver/Query.ts
@@ -58,7 +58,7 @@ export default class Query {
     traversal: TraversalType = TraversalType.PREORDER
   ): Selector {
     if (typeof type === "string") {
-      return new Selector().search(type, filter, traversal);
+      return new Selector().search(type, filter as Filter_StringVariant, traversal);
     } else {
       return new Selector().search(
         type,
@@ -115,7 +115,7 @@ export default class Query {
         traversal
       );
     } else {
-      return new Selector($baseJp).search(type, filter, traversal);
+      return new Selector($baseJp).search(type, filter as Filter_WrapperVariant<T>, traversal);
     }
   }
 

--- a/Lara-JS/src-api/weaver/Query.ts
+++ b/Lara-JS/src-api/weaver/Query.ts
@@ -28,9 +28,9 @@ export default class Query {
    *
    * @returns The results of the search.
    */
-  static search<T extends LaraJoinPoint>(
-    type: new (obj: unknown) => T,
-    filter?: JpFilter<T> | ((obj: T) => boolean),
+  static search<T extends typeof LaraJoinPoint>(
+    type: T,
+    filter?: JpFilter<InstanceType<T>> | ((obj: InstanceType<T>) => boolean),
     traversal?: TraversalType
   ): Selector;
   /**
@@ -49,9 +49,11 @@ export default class Query {
     filter?: SelectorFilter,
     traversal?: TraversalType
   ): Selector;
-  static search<T extends LaraJoinPoint>(
-    type: (new (obj: unknown) => T) | string,
-    filter?: (JpFilter<T> | ((obj: T) => boolean)) | SelectorFilter,
+  static search<T extends typeof LaraJoinPoint>(
+    type: T | string,
+    filter?:
+      | (JpFilter<InstanceType<T>> | ((obj: InstanceType<T>) => boolean))
+      | SelectorFilter,
     traversal: TraversalType = TraversalType.PREORDER
   ): Selector {
     if (typeof type === "string") {
@@ -59,7 +61,9 @@ export default class Query {
     } else {
       return new Selector().search(
         type,
-        filter as JpFilter<T> | ((obj: T) => boolean),
+        filter as
+          | JpFilter<InstanceType<T>>
+          | ((obj: InstanceType<T>) => boolean),
         traversal
       );
     }

--- a/Lara-JS/src-api/weaver/Query.ts
+++ b/Lara-JS/src-api/weaver/Query.ts
@@ -5,7 +5,6 @@ import Selector, {
   type Filter_WrapperVariant,
 } from "./Selector.js";
 import TraversalType from "./TraversalType.js";
-import Weaver from "./Weaver.js";
 
 /**
  * Class for selection of join points. Provides an API similar to the keyword 'select'.
@@ -36,7 +35,7 @@ export default class Query {
     type: T,
     filter?: Filter_WrapperVariant<T>,
     traversal?: TraversalType
-  ): Selector<InstanceType<T>>;
+  ): Selector<T>;
   /**
    * The same as Query.searchFrom(), but uses the root node as $baseJp.
    *
@@ -52,24 +51,20 @@ export default class Query {
     type: string,
     filter?: Filter_StringVariant,
     traversal?: TraversalType
-  ): Selector<LaraJoinPoint>;
+  ): Selector<typeof LaraJoinPoint>;
   static search<T extends typeof LaraJoinPoint = typeof LaraJoinPoint>(
     type: T | string,
     filter?: Filter_WrapperVariant<T> | Filter_StringVariant,
     traversal: TraversalType = TraversalType.PREORDER
-  ): Selector<InstanceType<T>> {
+  ): Selector<T> {
     if (typeof type === "string") {
-      filter = Selector.convertStringFilterToWrapperFilter(
+      return new Selector<typeof LaraJoinPoint>().search(
         type,
-        filter as Filter_StringVariant
+        filter as Filter_StringVariant,
+        traversal
       );
-      const jpType = Weaver.findJoinpointType(type) as T | undefined;
-      if (!jpType) {
-        throw new Error(`Join point type '${type}' not found.`);
-      }
-      return new Selector<LaraJoinPoint>().search(jpType, filter, traversal);
     } else {
-      return new Selector<InstanceType<T>>().search(
+      return new Selector<T>().search(
         type,
         filter as Filter_WrapperVariant<T>,
         traversal
@@ -92,7 +87,7 @@ export default class Query {
     type?: T,
     filter?: Filter_WrapperVariant<T>,
     traversal?: TraversalType
-  ): Selector<InstanceType<T>>;
+  ): Selector<T>;
   /**
    * In-depth search of nodes of the given type, starting from a base node (exclusive).
    *
@@ -110,25 +105,21 @@ export default class Query {
     type?: string,
     filter?: Filter_StringVariant,
     traversal?: TraversalType
-  ): Selector<LaraJoinPoint>;
+  ): Selector<typeof LaraJoinPoint>;
   static searchFrom<T extends typeof LaraJoinPoint>(
     $baseJp: LaraJoinPoint,
     type?: T | string,
     filter?: Filter_WrapperVariant<T> | Filter_StringVariant,
     traversal: TraversalType = TraversalType.PREORDER
-  ): Selector<InstanceType<T>> {
+  ): Selector<T> {
     if (typeof type === "string") {
-      filter = Selector.convertStringFilterToWrapperFilter(
+      return new Selector<typeof LaraJoinPoint>($baseJp).search(
         type,
-        filter as Filter_StringVariant
+        filter as Filter_StringVariant,
+        traversal
       );
-      const jpType = Weaver.findJoinpointType(type) as T | undefined;
-      if (!jpType) {
-        throw new Error(`Join point type '${type}' not found.`);
-      }
-      return new Selector($baseJp).search(jpType, filter, traversal);
     } else {
-      return new Selector($baseJp).search(
+      return new Selector<T>($baseJp).search(
         type,
         filter as Filter_WrapperVariant<T>,
         traversal
@@ -146,15 +137,12 @@ export default class Query {
    *
    * @returns The results of the search.
    */
-  static searchFromInclusive<
-    T extends typeof LaraJoinPoint,
-    TBase extends LaraJoinPoint,
-  >(
-    $baseJp: TBase,
+  static searchFromInclusive<T extends typeof LaraJoinPoint>(
+    $baseJp: LaraJoinPoint,
     type?: T,
     filter?: Filter_WrapperVariant<T>,
     traversal?: TraversalType
-  ): Selector<InstanceType<T>, InstanceType<T> | TBase>;
+  ): Selector<T>;
   /**
    * The same as Query.searchFrom(), but $baseJp is included in the search.
    *
@@ -172,28 +160,21 @@ export default class Query {
     type?: string,
     filter?: Filter_StringVariant,
     traversal?: TraversalType
-  ): Selector<LaraJoinPoint>;
-  static searchFromInclusive<
-    T extends typeof LaraJoinPoint,
-    TBase extends LaraJoinPoint,
-  >(
-    $baseJp: TBase,
+  ): Selector<typeof LaraJoinPoint>;
+  static searchFromInclusive<T extends typeof LaraJoinPoint>(
+    $baseJp: LaraJoinPoint,
     type?: T | string,
     filter?: Filter_WrapperVariant<T> | Filter_StringVariant,
     traversal: TraversalType = TraversalType.PREORDER
-  ): Selector<InstanceType<T>, InstanceType<T> | TBase> {
+  ): Selector<T> {
     if (typeof type === "string") {
-      filter = Selector.convertStringFilterToWrapperFilter(
+      return new Selector<typeof LaraJoinPoint>($baseJp, true).search(
         type,
-        filter as Filter_StringVariant
+        filter as Filter_StringVariant,
+        traversal
       );
-      const jpType = Weaver.findJoinpointType(type) as T | undefined;
-      if (!jpType) {
-        throw new Error(`Join point type '${type}' not found.`);
-      }
-      return new Selector($baseJp, true).search(jpType, filter, traversal);
     } else {
-      return new Selector($baseJp, true).search(
+      return new Selector<T>($baseJp, true).search(
         type,
         filter as Filter_WrapperVariant<T>,
         traversal
@@ -214,7 +195,7 @@ export default class Query {
     $baseJp: LaraJoinPoint,
     type?: T,
     filter?: Filter_WrapperVariant<T>
-  ): Selector<InstanceType<T>>;
+  ): Selector<T>;
   /**
    * Search the direct children of the given $baseJp.
    *
@@ -230,24 +211,19 @@ export default class Query {
     $baseJp: LaraJoinPoint,
     type?: string,
     filter?: Filter_StringVariant
-  ): Selector<LaraJoinPoint>;
+  ): Selector<typeof LaraJoinPoint>;
   static childrenFrom<T extends typeof LaraJoinPoint>(
     $baseJp: LaraJoinPoint,
     type?: T | string,
     filter?: Filter_WrapperVariant<T> | Filter_StringVariant
-  ): Selector<InstanceType<T>> {
+  ): Selector<T> {
     if (typeof type === "string") {
-      filter = Selector.convertStringFilterToWrapperFilter(
+      return new Selector<typeof LaraJoinPoint>($baseJp).children(
         type,
         filter as Filter_StringVariant
       );
-      const jpType = Weaver.findJoinpointType(type) as T | undefined;
-      if (!jpType) {
-        throw new Error(`Join point type '${type}' not found.`);
-      }
-      return new Selector($baseJp).children(jpType, filter);
     } else {
-      return new Selector($baseJp).children(
+      return new Selector<T>($baseJp).children(
         type,
         filter as Filter_WrapperVariant<T>
       );
@@ -267,7 +243,7 @@ export default class Query {
     $baseJp: LaraJoinPoint,
     type?: T,
     filter?: Filter_WrapperVariant<T>
-  ): Selector<InstanceType<T>>;
+  ): Selector<T>;
   /**
    * If $baseJp has the concept of scope (e.g. if, loop), search the direct children of that scope.
    *
@@ -283,24 +259,19 @@ export default class Query {
     $baseJp: LaraJoinPoint,
     type?: string,
     filter?: Filter_StringVariant
-  ): Selector<LaraJoinPoint>;
+  ): Selector<typeof LaraJoinPoint>;
   static scopeFrom<T extends typeof LaraJoinPoint>(
     $baseJp: LaraJoinPoint,
     type?: T | string,
     filter?: Filter_WrapperVariant<T> | Filter_StringVariant
-  ): Selector<InstanceType<T>> {
+  ): Selector<T> {
     if (typeof type === "string") {
-      filter = Selector.convertStringFilterToWrapperFilter(
+      return new Selector<typeof LaraJoinPoint>($baseJp).scope(
         type,
         filter as Filter_StringVariant
       );
-      const jpType = Weaver.findJoinpointType(type) as T | undefined;
-      if (!jpType) {
-        throw new Error(`Join point type '${type}' not found.`);
-      }
-      return new Selector($baseJp).scope(jpType, filter);
     } else {
-      return new Selector($baseJp).scope(
+      return new Selector<T>($baseJp).scope(
         type,
         filter as Filter_WrapperVariant<T>
       );

--- a/Lara-JS/src-api/weaver/Selector.ts
+++ b/Lara-JS/src-api/weaver/Selector.ts
@@ -172,21 +172,22 @@ export default class Selector<
     } else {
       // Filter must be an object (JpFilter type). Return a function that filters by the given rules.
       return (jp: InstanceType<T>): boolean => {
+        let allCriteriaMatch: boolean = true;
         for (const [k, v] of Object.entries(
           filter as JpFilter<InstanceType<T>>
         )) {
           if (v instanceof RegExp) {
-            return v.test(laraGetter(jp, k) as string);
+            allCriteriaMatch &&= v.test(laraGetter(jp, k) as string);
           } else if (typeof v === "function") {
-            return (v as FilterFunction<unknown, InstanceType<T>>)(
+            allCriteriaMatch &&= (v as FilterFunction<unknown, InstanceType<T>>)(
               laraGetter(jp, k),
               jp
             );
+          } else {
+            allCriteriaMatch &&= laraGetter(jp, k) === v;
           }
-
-          return laraGetter(jp, k) === v;
         }
-        return true;
+        return allCriteriaMatch;
       };
     }
   }
@@ -217,18 +218,20 @@ export default class Selector<
     }
 
     return (jp: LaraJoinPoint): boolean => {
+      let allCriteriaMatch: boolean = true;
       for (const [k, v] of Object.entries(filter)) {
         if (v instanceof RegExp) {
-          return v.test(laraGetter(jp, k) as string);
+          allCriteriaMatch &&= v.test(laraGetter(jp, k) as string);
         } else if (typeof v === "function") {
-          return (v as FilterFunction<unknown, LaraJoinPoint>)(
+          allCriteriaMatch &&= (v as FilterFunction<unknown, LaraJoinPoint>)(
             laraGetter(jp, k),
             jp
           );
+        } else {
+          allCriteriaMatch &&= laraGetter(jp, k) === v;
         }
-        return laraGetter(jp, k) === v;
       }
-      return true;
+      return allCriteriaMatch;
     };
   }
 

--- a/Lara-JS/src-api/weaver/Selector.ts
+++ b/Lara-JS/src-api/weaver/Selector.ts
@@ -53,6 +53,24 @@ export type JpFilter<T> = {
     ? never
     : key]?: ExpandedRules<T, key>;
 };
+type JpFilterFunction<T extends typeof LaraJoinPoint = typeof LaraJoinPoint> = (
+  jp: InstanceType<T>
+) => boolean;
+
+type AllowedDefaultAttributeTypes = StringExpander<string | number | bigint | boolean>;
+function isAllowedDefaultAttributeType(
+  obj: unknown
+): obj is AllowedDefaultAttributeTypes {
+  if (obj instanceof RegExp) return true;
+
+  const type = typeof obj;
+  return (
+    type === "string" ||
+    type === "number" ||
+    type === "bigint" ||
+    type === "boolean"
+  );
+}
 
 interface SelectorChain {
   counter: Accumulator;

--- a/Lara-JS/src-api/weaver/Selector.ts
+++ b/Lara-JS/src-api/weaver/Selector.ts
@@ -28,17 +28,19 @@ export type MemberType<T, key extends keyof T> = key extends never
     ? R
     : T[key];
 
+type FilterFunction<T, Class> = ((value: T, obj: Class) => boolean);
+
 /**
  * If the type is a string, expands it to a string or a RegExp.
  */
-type StringExpander<T> = T extends string ? T | RegExp | (() => string) : T;
+type StringExpander<T> = T extends string ? T | RegExp : T;
 
 /**
  * Expand type to allow for the basic type or a filter function accepting the basic type.
  */
 type FilterFunctionExpander<T, Class> = T extends never
   ? never
-  : T | ((value: T, obj: Class) => boolean);
+  : T | FilterFunction<T, Class>;
 
 type ExpandedRules<T, key extends keyof T> = StringExpander<
   FilterFunctionExpander<MemberType<T, key>, T>
@@ -201,10 +203,8 @@ export default class Selector {
     if (type !== undefined && typeof type !== "string") {
       if (typeof filter === "object") {
         jpFilter = new JpFilterClass(filter as JpFilterRules);
-      } else if (typeof filter === "function") {
-        jpFilter = Selector.parseFilter(filter as Filter_StringVariant, type);
       } else {
-        throw new TypeError("Invalid filter type: " + typeof filter);
+        jpFilter = Selector.parseFilter(filter as Filter_StringVariant, type);
       }
     } else {
       jpFilter = Selector.parseFilter(filter as Filter_StringVariant, type);
@@ -264,10 +264,8 @@ export default class Selector {
     if (type !== undefined && typeof type !== "string") {
       if (typeof filter === "object") {
         jpFilter = new JpFilterClass(filter as JpFilterRules);
-      } else if (typeof filter === "function") {
-        jpFilter = Selector.parseFilter(filter as Filter_StringVariant, type);
       } else {
-        throw new TypeError("Invalid filter type: " + typeof filter);
+        jpFilter = Selector.parseFilter(filter as Filter_StringVariant, type);
       }
     } else {
       jpFilter = Selector.parseFilter(filter as Filter_StringVariant, type);
@@ -314,10 +312,8 @@ export default class Selector {
     if (type !== undefined && typeof type !== "string") {
       if (typeof filter === "object") {
         jpFilter = new JpFilterClass(filter as JpFilterRules);
-      } else if (typeof filter === "function") {
-        jpFilter = Selector.parseFilter(filter as Filter_StringVariant, type);
       } else {
-        throw new TypeError("Invalid filter type: " + typeof filter);
+        jpFilter = Selector.parseFilter(filter as Filter_StringVariant, type);
       }
     } else {
       jpFilter = Selector.parseFilter(filter as Filter_StringVariant, type);

--- a/Lara-JS/src-api/weaver/Selector.ts
+++ b/Lara-JS/src-api/weaver/Selector.ts
@@ -238,14 +238,14 @@ export default class Selector<
    * Returns join points iteratively, as if .get() was called.
    */
   *[Symbol.iterator]() {
-    if (this.$currentJps.length > 0) {
-      for (const $jpChain of this.$currentJps) {
-        yield $jpChain.jpAttributes[this.lastName] as InstanceType<JpT>;
-      }
-    } else {
+    if (this.lastName === Selector.STARTING_POINT) {
       console.log(
         "Selector.iterator*: no join points have been searched, have you called a search function? (e.g., search, children)"
       );
+    } else {
+      for (const $jpChain of this.$currentJps) {
+        yield $jpChain.jpAttributes[this.lastName] as InstanceType<JpT>;
+      }
     }
     this.$currentJps = [];
   }
@@ -511,7 +511,7 @@ export default class Selector<
    * @returns an array with the join points of the last chain (e.g., search("function").search("call").get() returns an array of $call join points).
    */
   get(): InstanceType<JpT>[] {
-    if (this.$currentJps.length === 0) {
+    if (this.lastName === Selector.STARTING_POINT) {
       console.log(
         "Selector.get(): no join points have been searched, have you called a search function? (e.g., search, children)"
       );
@@ -531,7 +531,7 @@ export default class Selector<
    * @returns An array of objects where each object maps the name of the join point to the corresponding join point that was searched, as well as creating mappings of the format \<joinpoint_name\>_\<repetition\>. For instance, if the search chain has the same name multiple times (e.g., search("loop").search("loop")), the chain object will have an attribute "loop" mapped to the last loop of the chain, an attribute "loop_0" mapped to the first loop of the chain and an attribute "loop_1" mapped to the second loop of the chain.
    */
   chain() {
-    if (this.$currentJps.length === 0) {
+    if (this.lastName === Selector.STARTING_POINT) {
       console.log(
         "Selector.get(): no join points have been searched, have you called a search function? (e.g., search, children)"
       );

--- a/Lara-JS/src-api/weaver/Selector.ts
+++ b/Lara-JS/src-api/weaver/Selector.ts
@@ -193,8 +193,12 @@ export default class Selector<
 
   public static convertStringFilterToWrapperFilter(
     joinPointType: string = "",
-    filter: Filter_StringVariant = {}
+    filter?: Filter_StringVariant
   ): JpFilterFunction {
+    if (filter == undefined) {
+      return () => true;
+    }
+
     // If filter is not an object, or if it is a regex, build object with default attribute of given jp name
     if (typeof filter !== "object" || filter instanceof RegExp) {
       // Get default attribute
@@ -274,7 +278,7 @@ export default class Selector<
   ): Selector;
   search<T extends typeof LaraJoinPoint>(
     type: T | string = LaraJoinPoint as T,
-    filter: Filter_WrapperVariant<T> | Filter_StringVariant = () => true,
+    filter?: Filter_WrapperVariant<T> | Filter_StringVariant,
     traversal: TraversalType = TraversalType.PREORDER
   ): Selector<T, ChU | T> {
     let jpFilter: JpFilterFunction<T>;
@@ -292,7 +296,7 @@ export default class Selector<
     } else {
       jpFilter = Selector.parseWrapperFilter(
         type,
-        filter as Filter_WrapperVariant<T>
+        (filter as Filter_WrapperVariant<T>) ?? (() => true)
       );
     }
 
@@ -343,7 +347,7 @@ export default class Selector<
   children(name?: string, filter?: Filter_StringVariant): Selector;
   children<T extends typeof LaraJoinPoint>(
     type: T | string = LaraJoinPoint as T,
-    filter: Filter_WrapperVariant<T> | Filter_StringVariant = () => true
+    filter: Filter_WrapperVariant<T> | Filter_StringVariant
   ): Selector<T, ChU | T> {
     let jpFilter: JpFilterFunction<T>;
 
@@ -360,7 +364,7 @@ export default class Selector<
     } else {
       jpFilter = Selector.parseWrapperFilter(
         type,
-        filter as Filter_WrapperVariant<T>
+        (filter as Filter_WrapperVariant<T>) ?? (() => true)
       );
     }
 
@@ -398,7 +402,7 @@ export default class Selector<
   scope(name?: string, filter?: Filter_StringVariant): Selector;
   scope<T extends typeof LaraJoinPoint>(
     type: T | string = LaraJoinPoint as T,
-    filter: Filter_WrapperVariant<T> | Filter_StringVariant = () => true
+    filter: Filter_WrapperVariant<T> | Filter_StringVariant
   ): Selector<T, ChU | T> {
     let jpFilter: JpFilterFunction<T>;
 
@@ -415,7 +419,7 @@ export default class Selector<
     } else {
       jpFilter = Selector.parseWrapperFilter(
         type,
-        filter as Filter_WrapperVariant<T>
+        (filter as Filter_WrapperVariant<T>) ?? (() => true)
       );
     }
 

--- a/Lara-JS/src-api/weaver/Selector.ts
+++ b/Lara-JS/src-api/weaver/Selector.ts
@@ -443,6 +443,14 @@ export default class Selector<
     const name = Weaver.findJoinpointTypeName(type) ?? "joinpoint";
     const $newJps: SelectorChain[] = [];
 
+    /**
+     * Lara Common Language dirty hack. REMOVE ME PLEASE!
+     */
+    if (selectorJoinPointsClass !== JoinPoints && type === LaraJoinPoint) {
+      // We are in LCL mode.
+      throw new Error("In LCL mode you are required to specify a type in a search.");
+    }
+
     // If add base jp, this._$currentJps must have at most 1 element
     if (this.addBaseJp && this.$currentJps.length > 0) {
       if (this.$currentJps.length > 1) {

--- a/Lara-JS/src-api/weaver/Weaver.ts
+++ b/Lara-JS/src-api/weaver/Weaver.ts
@@ -1,4 +1,8 @@
-import { LaraJoinPoint, wrapJoinPoint } from "../LaraJoinPoint.js";
+import {
+  LaraJoinPoint,
+  getJoinpointMappers,
+  wrapJoinPoint,
+} from "../LaraJoinPoint.js";
 import JavaInterop from "../lara/JavaInterop.js";
 import Strings from "../lara/Strings.js";
 import DataStore from "../lara/util/DataStore.js";
@@ -79,13 +83,55 @@ export default class Weaver {
    * @param joinPointType - The type of the join point
    * @returns The name of the default attribute for the given join point type, or undefined if there is no default attribute
    */
-  static getDefaultAttribute(joinPointType: string): string {
+  static getDefaultAttribute<T extends typeof LaraJoinPoint>(
+    joinPointType: T
+  ): string | null;
+  static getDefaultAttribute(joinPointType: string): string | null;
+  static getDefaultAttribute<T extends typeof LaraJoinPoint>(
+    joinPointType: T | string
+  ): string | null;
+  static getDefaultAttribute<T extends typeof LaraJoinPoint>(
+    joinPointType: T | string
+  ): string | null {
     if (usingLaraCommonLanguage === true) {
-      return Java.type(
+      return JavaTypes.getType(
         "pt.up.fe.specs.lara.commonlang.LaraCommonLang"
-      ).getDefaultAttribute(joinPointType);
+      ).getDefaultAttribute(joinPointType) as string | null;
     }
-    return Weaver.getWeaverEngine().getDefaultAttribute(joinPointType);
+
+    if (typeof joinPointType === "string") {
+      // Search for the default attribute in the joinpoint mappers
+      for (const mapper of getJoinpointMappers()) {
+        if (mapper[joinPointType]) {
+          return mapper[joinPointType]._defaultAttribute;
+        }
+      }
+
+      // No wrapper was found, attempt to the collect information from the weaver
+      return Weaver.getWeaverEngine().getDefaultAttribute(joinPointType);
+    } else {
+      return joinPointType._defaultAttribute;
+    }
+  }
+
+  /**
+   * Finds the name of the joinpoint class, given the js wrapper class itself
+   * @param type - The joinpoint class to find the name of
+   * @returns The name of the joinpoint class
+   */
+  static findJoinpointTypeName<T extends typeof LaraJoinPoint>(
+    type: T
+  ): string {
+    const joinpointMappers = getJoinpointMappers();
+
+    for (const mapper of joinpointMappers) {
+      const match = Object.keys(mapper).find((key) => mapper[key] === type);
+      if (match) {
+        return match;
+      }
+    }
+
+    throw new Error("Joinpoint type not found: " + type.name);
   }
 
   /**

--- a/Lara-JS/src-api/weaver/Weaver.ts
+++ b/Lara-JS/src-api/weaver/Weaver.ts
@@ -84,14 +84,14 @@ export default class Weaver {
    */
   static getDefaultAttribute<T extends typeof LaraJoinPoint>(
     joinPointType: T
-  ): string | null;
+  ): keyof T | null;
   static getDefaultAttribute(joinPointType: string): string | null;
   static getDefaultAttribute<T extends typeof LaraJoinPoint>(
     joinPointType: T | string
-  ): string | null;
+  ): keyof T | string | null;
   static getDefaultAttribute<T extends typeof LaraJoinPoint>(
     joinPointType: T | string
-  ): string | null {
+  ): keyof T | string | null {
     if (usingLaraCommonLanguage === true) {
       return JavaTypes.getType(
         "pt.up.fe.specs.lara.commonlang.LaraCommonLang"

--- a/Lara-JS/src-api/weaver/Weaver.ts
+++ b/Lara-JS/src-api/weaver/Weaver.ts
@@ -6,7 +6,7 @@ import {
 import JavaInterop from "../lara/JavaInterop.js";
 import Strings from "../lara/Strings.js";
 import DataStore from "../lara/util/DataStore.js";
-import JavaTypes from "../lara/util/JavaTypes.js";
+import JavaTypes, { JavaClasses } from "../lara/util/JavaTypes.js";
 import PrintOnce from "../lara/util/PrintOnce.js";
 import WeaverOptions from "./WeaverOptions.js";
 
@@ -32,10 +32,9 @@ export default class Weaver {
   static DEFAULT_WEAVER_COMMAND = undefined;
 
   /**
-   *
-   * @returns {J#org.lara.interpreter.weaver.interf.WeaverEngine} the Java instance of the current WeaverEngine
+   * @returns The Java instance of the current WeaverEngine
    */
-  static getWeaverEngine() {
+  static getWeaverEngine(): JavaClasses.WeaverEngine {
     return JavaTypes.WeaverEngine.getThreadLocalWeaver();
   }
 

--- a/Lara-JS/src-api/weaver/Weaver.ts
+++ b/Lara-JS/src-api/weaver/Weaver.ts
@@ -46,8 +46,8 @@ export default class Weaver {
   }
 
   static getLaraLocTotals() {
-    var laraLoc = Java.type("pt.up.fe.specs.lara.loc.LaraLoc");
-    return Java.type("org.lara.interpreter.utils.LaraIUtils")
+    var laraLoc = JavaTypes.getType("pt.up.fe.specs.lara.loc.LaraLoc");
+    return JavaTypes.getType("org.lara.interpreter.utils.LaraIUtils")
       .getLaraLoc(
         Weaver.getWeaverEngine(),
         Weaver.getWeaverEngine().getData().get()

--- a/Lara-JS/src-api/weaver/Weaver.ts
+++ b/Lara-JS/src-api/weaver/Weaver.ts
@@ -120,7 +120,7 @@ export default class Weaver {
    */
   static findJoinpointTypeName<T extends typeof LaraJoinPoint>(
     type: T
-  ): string {
+  ): string | undefined {
     const joinpointMappers = getJoinpointMappers();
 
     for (const mapper of joinpointMappers) {
@@ -130,7 +130,19 @@ export default class Weaver {
       }
     }
 
-    throw new Error("Joinpoint type not found: " + type.name);
+    return undefined;
+  }
+
+  static findJoinpointType(name: string): typeof LaraJoinPoint | undefined {
+    const joinpointMappers = getJoinpointMappers();
+
+    for (const mapper of joinpointMappers) {
+      if (mapper[name]) {
+        return mapper[name];
+      }
+    }
+
+    return undefined;
   }
 
   /**

--- a/Lara-JS/src-api/weaver/Weaver.ts
+++ b/Lara-JS/src-api/weaver/Weaver.ts
@@ -102,14 +102,14 @@ export default class Weaver {
       // Search for the default attribute in the joinpoint mappers
       for (const mapper of getJoinpointMappers()) {
         if (mapper[joinPointType]) {
-          return mapper[joinPointType]._defaultAttribute;
+          return mapper[joinPointType]._defaultAttributeInfo.name;
         }
       }
 
       // No wrapper was found, attempt to the collect information from the weaver
       return Weaver.getWeaverEngine().getDefaultAttribute(joinPointType);
     } else {
-      return joinPointType._defaultAttribute;
+      return joinPointType._defaultAttributeInfo.name;
     }
   }
 

--- a/LaraApi/src-lara/LaraJoinPoint.js
+++ b/LaraApi/src-lara/LaraJoinPoint.js
@@ -42,6 +42,12 @@ export function registerJoinpointMapper(mapper) {
 export function clearJoinpointMappers() {
     JoinpointMappers.length = 0;
 }
+/**
+ * This function is for internal use only. DO NOT USE IT!
+ */
+export function getJoinpointMappers() {
+    return JoinpointMappers;
+}
 export function wrapJoinPoint(obj) {
     if (JoinpointMappers.length === 0) {
         return obj;

--- a/LaraApi/src-lara/LaraJoinPoint.js
+++ b/LaraApi/src-lara/LaraJoinPoint.js
@@ -10,8 +10,10 @@
 /* eslint-disable @typescript-eslint/no-duplicate-type-constituents */
 import JavaTypes from "./lara/util/JavaTypes.js";
 export class LaraJoinPoint {
+    static _defaultAttributeInfo = {
+        name: null,
+    };
     _javaObject;
-    static _defaultAttribute = null;
     constructor(obj) {
         this._javaObject = obj;
     }

--- a/LaraApi/src-lara/lara/Collections.js
+++ b/LaraApi/src-lara/lara/Collections.js
@@ -5,11 +5,6 @@ import JavaTypes from "./util/JavaTypes.js";
  *
  */
 export default class Collections {
-    /**
-     * @param values - Values to sort in-place. Must be of type \{Object[]|java.util.List\}
-     *
-     * @returns The sorted collection
-     */
     static sort(values) {
         // If array
         if (values instanceof Array) {

--- a/LaraApi/src-lara/lara/JavaInterop.js
+++ b/LaraApi/src-lara/lara/JavaInterop.js
@@ -31,7 +31,7 @@ export default class JavaInterop {
      * @deprecated Use JavaTypes instead
      */
     static getClass(classname) {
-        return Java.type(classname).class;
+        return JavaTypes.getType(classname).class;
     }
 }
 //# sourceMappingURL=JavaInterop.js.map

--- a/LaraApi/src-lara/weaver/JoinPoints.js
+++ b/LaraApi/src-lara/weaver/JoinPoints.js
@@ -16,7 +16,7 @@ export default class JoinPoints {
      *
      */
     static toJoinPoint(node) {
-        throw "JoinPoints.toJoinPoint: not implemented";
+        throw new Error("JoinPoints.toJoinPoint: not implemented");
     }
     /**
      *
@@ -65,44 +65,39 @@ export default class JoinPoints {
      * @returns the nodes inside the scope of the given node.
      */
     static scope($jp, jpType) {
-        return JoinPoints._getNodes(JoinPoints._all_scope_nodes, $jp, jpType);
+        return JoinPoints._getNodes(jpType, JoinPoints._all_scope_nodes($jp));
     }
     /**
      *
      * @returns the children of the given node, according to the AST
      */
     static children($jp, jpType) {
-        return JoinPoints._getNodes(JoinPoints._all_children, $jp, jpType);
+        return JoinPoints._getNodes(jpType, JoinPoints._all_children($jp));
     }
     /**
      *
      * @returns the descendants of the given node, according to the AST, preorder traversal
      */
     static descendants($jp, jpType) {
-        return JoinPoints._getNodes(JoinPoints._all_descendants, $jp, jpType);
+        return JoinPoints._getNodes(jpType, JoinPoints._all_descendants($jp));
     }
     /**
      *
      * @returns the descendants of the given node, according to the AST, postorder traversal
      */
     static descendantsPostorder($jp, jpType) {
-        return JoinPoints._getNodes(JoinPoints._all_descendants_postorder, $jp, jpType);
+        return JoinPoints._getNodes(jpType, JoinPoints._all_descendants_postorder($jp));
     }
     /**
      *
      * @returns  the nodes related with the given node, according to the search function
      */
-    static _getNodes(searchFunction, $jp, jpType) {
+    static _getNodes(jpType, $allJps = []) {
         // TODO: This function can be optimized by using streaming
-        const descendants = searchFunction($jp);
         if (jpType === undefined) {
-            return descendants;
+            return $allJps;
         }
-        return JoinPoints._filterNodes(descendants, jpType);
-    }
-    static _filterNodes($jps, jpType) {
-        // TODO: This check should be done with the JS Classes
-        return $jps.filter((jp) => jp.instanceOf(jpType));
+        return $allJps.filter((jp) => jp instanceof jpType);
     }
     /**
      * Iterates of attributeNames, returns the first value that is not null or undefined.

--- a/LaraApi/src-lara/weaver/Query.js
+++ b/LaraApi/src-lara/weaver/Query.js
@@ -24,56 +24,37 @@ export default class Query {
             return new Selector().search(type, filter, traversal);
         }
     }
-    /**
-     * In-depth search of nodes of the given type, starting from a base node (exclusive).
-     *
-     * @param $baseJp - starting join point for the search.
-     * @param type - type of the join point to search.
-     * @param filter - filter rules for the search. If the value is an object, each field of the object represents a rule that will be applied over the attribute that has the same name as the name of the field. If the value is not an object (e.g., String, Regex, Lambda), it is interpreted as a single rule that will be applied over the default attribute of the given type. E.g., if type is 'function', the value is a String 'foo' and the default attribute of function is 'name', this is equivalent as passing as value the object \{'name':'foo'\}. Rules can be a String (i.e., will match the value of the attribute against a string), a Regex (will match the value of the attribute against a regex) or a Function (i.e., function receives the value of the attribute and returns true if there is a match, or false otherwise).
-     * @param traversal - AST traversal type, according to weaver.TraversalType
-     *
-     * @returns The results of the search.
-     */
     static searchFrom($baseJp, type, filter, traversal = TraversalType.PREORDER) {
-        return new Selector($baseJp).search(type, filter, traversal);
+        if (typeof type === "string") {
+            return new Selector($baseJp).search(type, filter, traversal);
+        }
+        else {
+            return new Selector($baseJp).search(type, filter, traversal);
+        }
     }
-    /**
-     * The same as Query.searchFrom(), but $baseJp is included in the search.
-     *
-     * @param $baseJp - starting join point for the search.
-     * @param type - type of the join point to search.
-     * @param filter - filter rules for the search.
-     * @param traversal - AST traversal type, according to weaver.TraversalType
-     *
-     * @returns The results of the search.
-     */
     static searchFromInclusive($baseJp, type, filter, traversal = TraversalType.PREORDER) {
-        return new Selector($baseJp, true).search(type, filter, traversal);
+        if (typeof type === "string") {
+            return new Selector($baseJp, true).search(type, filter, traversal);
+        }
+        else {
+            return new Selector($baseJp, true).search(type, filter, traversal);
+        }
     }
-    /**
-     * Search the direct children of the given $baseJp.
-     *
-     * @param $baseJp - starting join point for the search.
-     * @param type - type of the join point to search.
-     * @param filter - filter rules for the search.
-     *
-     * @returns The results of the search.
-     */
     static childrenFrom($baseJp, type, filter) {
-        // These rules will be used to create a lara.util.JpFilter instance, please refer to that class for details on what kinds of rules are supported.
-        return new Selector($baseJp).children(type, filter);
+        if (typeof type === "string") {
+            return new Selector($baseJp).children(type, filter);
+        }
+        else {
+            return new Selector($baseJp).children(type, filter);
+        }
     }
-    /**
-     * If $baseJp has the concept of scope (e.g. if, loop), search the direct children of that scope.
-     *
-     * @param $baseJp - starting join point for the search.
-     * @param type - type of the join point to search.
-     * @param filter - filter rules for the search.
-     *
-     * @returns The results of the search.
-     */
     static scopeFrom($baseJp, type, filter) {
-        return new Selector($baseJp).scope(type, filter);
+        if (typeof type === "string") {
+            return new Selector($baseJp).scope(type, filter);
+        }
+        else {
+            return new Selector($baseJp).scope(type, filter);
+        }
     }
 }
 //# sourceMappingURL=Query.js.map

--- a/LaraApi/src-lara/weaver/Query.js
+++ b/LaraApi/src-lara/weaver/Query.js
@@ -16,17 +16,13 @@ export default class Query {
     static root() {
         return JoinPoints.root();
     }
-    /**
-     * The same as Query.searchFrom(), but uses the root node as $baseJp.
-     *
-     * @param type - type of the join point to search.
-     * @param filter - filter rules for the search. If the value is an object, each field of the object represents a rule that will be applied over the attribute that has the same name as the name of the field. If the value is not an object (e.g., String, Regex, Lambda), it is interpreted as a single rule that will be applied over the default attribute of the given type. E.g., if type is 'function', the value is a String 'foo' and the default attribute of function is 'name', this is equivalent as passing as value the object \{'name':'foo'\}. Rules can be a String (i.e., will match the value of the attribute against a string), a Regex (will match the value of the attribute against a regex) or a Function (i.e., function receives the value of the attribute and returns true if there is a match, or false otherwise).
-     * @param traversal - AST traversal type, according to weaver.TraversalType
-     *
-     * @returns The results of the search.
-     */
     static search(type, filter, traversal = TraversalType.PREORDER) {
-        return new Selector().search(type, filter, traversal);
+        if (typeof type === "string") {
+            return new Selector().search(type, filter, traversal);
+        }
+        else {
+            return new Selector().search(type, filter, traversal);
+        }
     }
     /**
      * In-depth search of nodes of the given type, starting from a base node (exclusive).

--- a/LaraApi/src-lara/weaver/Script.js
+++ b/LaraApi/src-lara/weaver/Script.js
@@ -1,7 +1,8 @@
+import Weaver from "./Weaver.js";
 /**
  * Utility methods related to execution of scripts in a LARA environment.
  *
- * @deprecated Nothing uses this and methods reference variables that do not exist
+ * @deprecated Nothing uses this
  */
 export default class Script {
     static #scriptOutput = {};
@@ -27,7 +28,7 @@ export default class Script {
      * @returns An object with the input arguments passed by command line
      */
     static getInput() {
-        return {}; //laraArgs; Comment: laraArgs does not exist anywhere in the codebase
+        return Weaver.laraArgs;
     }
 }
 //# sourceMappingURL=Script.js.map

--- a/LaraApi/src-lara/weaver/Selector.js
+++ b/LaraApi/src-lara/weaver/Selector.js
@@ -206,6 +206,13 @@ export default class Selector {
     searchPrivate(type, selectFunction, jpFilter = () => true) {
         const name = Weaver.findJoinpointTypeName(type) ?? "joinpoint";
         const $newJps = [];
+        /**
+         * Lara Common Language dirty hack. REMOVE ME PLEASE!
+         */
+        if (selectorJoinPointsClass !== JoinPoints && type === LaraJoinPoint) {
+            // We are in LCL mode.
+            throw new Error("In LCL mode you are required to specify a type in a search.");
+        }
         // If add base jp, this._$currentJps must have at most 1 element
         if (this.addBaseJp && this.$currentJps.length > 0) {
             if (this.$currentJps.length > 1) {

--- a/LaraApi/src-lara/weaver/Selector.js
+++ b/LaraApi/src-lara/weaver/Selector.js
@@ -121,13 +121,13 @@ export default class Selector {
      * Returns join points iteratively, as if .get() was called.
      */
     *[Symbol.iterator]() {
-        if (this.$currentJps.length > 0) {
+        if (this.lastName === Selector.STARTING_POINT) {
+            console.log("Selector.iterator*: no join points have been searched, have you called a search function? (e.g., search, children)");
+        }
+        else {
             for (const $jpChain of this.$currentJps) {
                 yield $jpChain.jpAttributes[this.lastName];
             }
-        }
-        else {
-            console.log("Selector.iterator*: no join points have been searched, have you called a search function? (e.g., search, children)");
         }
         this.$currentJps = [];
     }
@@ -246,7 +246,7 @@ export default class Selector {
      * @returns an array with the join points of the last chain (e.g., search("function").search("call").get() returns an array of $call join points).
      */
     get() {
-        if (this.$currentJps.length === 0) {
+        if (this.lastName === Selector.STARTING_POINT) {
             console.log("Selector.get(): no join points have been searched, have you called a search function? (e.g., search, children)");
             return [];
         }
@@ -258,7 +258,7 @@ export default class Selector {
      * @returns An array of objects where each object maps the name of the join point to the corresponding join point that was searched, as well as creating mappings of the format \<joinpoint_name\>_\<repetition\>. For instance, if the search chain has the same name multiple times (e.g., search("loop").search("loop")), the chain object will have an attribute "loop" mapped to the last loop of the chain, an attribute "loop_0" mapped to the first loop of the chain and an attribute "loop_1" mapped to the second loop of the chain.
      */
     chain() {
-        if (this.$currentJps.length === 0) {
+        if (this.lastName === Selector.STARTING_POINT) {
             console.log("Selector.get(): no join points have been searched, have you called a search function? (e.g., search, children)");
             return [];
         }

--- a/LaraApi/src-lara/weaver/Selector.js
+++ b/LaraApi/src-lara/weaver/Selector.js
@@ -86,7 +86,10 @@ export default class Selector {
             };
         }
     }
-    static convertStringFilterToWrapperFilter(joinPointType = "", filter = {}) {
+    static convertStringFilterToWrapperFilter(joinPointType = "", filter) {
+        if (filter == undefined) {
+            return () => true;
+        }
         // If filter is not an object, or if it is a regex, build object with default attribute of given jp name
         if (typeof filter !== "object" || filter instanceof RegExp) {
             // Get default attribute
@@ -128,7 +131,7 @@ export default class Selector {
         }
         this.$currentJps = [];
     }
-    search(type = LaraJoinPoint, filter = () => true, traversal = TraversalType.PREORDER) {
+    search(type = LaraJoinPoint, filter, traversal = TraversalType.PREORDER) {
         let jpFilter;
         if (typeof type === "string") {
             jpFilter = Selector.convertStringFilterToWrapperFilter(type, filter);
@@ -139,7 +142,7 @@ export default class Selector {
             return this.search(jpType, jpFilter, traversal);
         }
         else {
-            jpFilter = Selector.parseWrapperFilter(type, filter);
+            jpFilter = Selector.parseWrapperFilter(type, filter ?? (() => true));
         }
         let fn;
         switch (traversal) {
@@ -160,7 +163,7 @@ export default class Selector {
         }
         return this.searchPrivate(type, fn, jpFilter);
     }
-    children(type = LaraJoinPoint, filter = () => true) {
+    children(type = LaraJoinPoint, filter) {
         let jpFilter;
         if (typeof type === "string") {
             jpFilter = Selector.convertStringFilterToWrapperFilter(type, filter);
@@ -171,13 +174,13 @@ export default class Selector {
             return this.children(jpType, jpFilter);
         }
         else {
-            jpFilter = Selector.parseWrapperFilter(type, filter);
+            jpFilter = Selector.parseWrapperFilter(type, filter ?? (() => true));
         }
         return this.searchPrivate(type, function ($jp, name) {
             return selectorJoinPointsClass.children($jp, name);
         }, jpFilter);
     }
-    scope(type = LaraJoinPoint, filter = () => true) {
+    scope(type = LaraJoinPoint, filter) {
         let jpFilter;
         if (typeof type === "string") {
             jpFilter = Selector.convertStringFilterToWrapperFilter(type, filter);
@@ -188,7 +191,7 @@ export default class Selector {
             return this.scope(jpType, jpFilter);
         }
         else {
-            jpFilter = Selector.parseWrapperFilter(type, filter);
+            jpFilter = Selector.parseWrapperFilter(type, filter ?? (() => true));
         }
         return this.searchPrivate(type, function ($jp, name) {
             return selectorJoinPointsClass.scope($jp, name);

--- a/LaraApi/src-lara/weaver/Selector.js
+++ b/LaraApi/src-lara/weaver/Selector.js
@@ -73,16 +73,19 @@ export default class Selector {
         else {
             // Filter must be an object (JpFilter type). Return a function that filters by the given rules.
             return (jp) => {
+                let allCriteriaMatch = true;
                 for (const [k, v] of Object.entries(filter)) {
                     if (v instanceof RegExp) {
-                        return v.test(laraGetter(jp, k));
+                        allCriteriaMatch &&= v.test(laraGetter(jp, k));
                     }
                     else if (typeof v === "function") {
-                        return v(laraGetter(jp, k), jp);
+                        allCriteriaMatch &&= v(laraGetter(jp, k), jp);
                     }
-                    return laraGetter(jp, k) === v;
+                    else {
+                        allCriteriaMatch &&= laraGetter(jp, k) === v;
+                    }
                 }
-                return true;
+                return allCriteriaMatch;
             };
         }
     }
@@ -103,16 +106,19 @@ export default class Selector {
             });
         }
         return (jp) => {
+            let allCriteriaMatch = true;
             for (const [k, v] of Object.entries(filter)) {
                 if (v instanceof RegExp) {
-                    return v.test(laraGetter(jp, k));
+                    allCriteriaMatch &&= v.test(laraGetter(jp, k));
                 }
                 else if (typeof v === "function") {
-                    return v(laraGetter(jp, k), jp);
+                    allCriteriaMatch &&= v(laraGetter(jp, k), jp);
                 }
-                return laraGetter(jp, k) === v;
+                else {
+                    allCriteriaMatch &&= laraGetter(jp, k) === v;
+                }
             }
-            return true;
+            return allCriteriaMatch;
         };
     }
     /**

--- a/LaraApi/src-lara/weaver/Selector.js
+++ b/LaraApi/src-lara/weaver/Selector.js
@@ -86,11 +86,8 @@ export default class Selector {
             if (typeof filter === "object") {
                 jpFilter = new JpFilterClass(filter);
             }
-            else if (typeof filter === "function") {
-                jpFilter = Selector.parseFilter(filter, type);
-            }
             else {
-                throw new TypeError("Invalid filter type: " + typeof filter);
+                jpFilter = Selector.parseFilter(filter, type);
             }
         }
         else {
@@ -121,11 +118,8 @@ export default class Selector {
             if (typeof filter === "object") {
                 jpFilter = new JpFilterClass(filter);
             }
-            else if (typeof filter === "function") {
-                jpFilter = Selector.parseFilter(filter, type);
-            }
             else {
-                throw new TypeError("Invalid filter type: " + typeof filter);
+                jpFilter = Selector.parseFilter(filter, type);
             }
         }
         else {
@@ -141,11 +135,8 @@ export default class Selector {
             if (typeof filter === "object") {
                 jpFilter = new JpFilterClass(filter);
             }
-            else if (typeof filter === "function") {
-                jpFilter = Selector.parseFilter(filter, type);
-            }
             else {
-                throw new TypeError("Invalid filter type: " + typeof filter);
+                jpFilter = Selector.parseFilter(filter, type);
             }
         }
         else {

--- a/LaraApi/src-lara/weaver/Weaver.js
+++ b/LaraApi/src-lara/weaver/Weaver.js
@@ -33,8 +33,8 @@ export default class Weaver {
         return JavaTypes.LaraIUtils.getLaraLoc(Weaver.getWeaverEngine(), Weaver.getWeaverEngine().getData().get());
     }
     static getLaraLocTotals() {
-        var laraLoc = Java.type("pt.up.fe.specs.lara.loc.LaraLoc");
-        return Java.type("org.lara.interpreter.utils.LaraIUtils")
+        var laraLoc = JavaTypes.getType("pt.up.fe.specs.lara.loc.LaraLoc");
+        return JavaTypes.getType("org.lara.interpreter.utils.LaraIUtils")
             .getLaraLoc(Weaver.getWeaverEngine(), Weaver.getWeaverEngine().getData().get())
             .get(laraLoc.getTotalsKey());
     }
@@ -85,7 +85,16 @@ export default class Weaver {
                 return match;
             }
         }
-        throw new Error("Joinpoint type not found: " + type.name);
+        return undefined;
+    }
+    static findJoinpointType(name) {
+        const joinpointMappers = getJoinpointMappers();
+        for (const mapper of joinpointMappers) {
+            if (mapper[name]) {
+                return mapper[name];
+            }
+        }
+        return undefined;
     }
     /**
      * @param jpTypeName - a join point, or the name of a join point

--- a/LaraApi/src-lara/weaver/Weaver.js
+++ b/LaraApi/src-lara/weaver/Weaver.js
@@ -24,8 +24,7 @@ export default class Weaver {
      */
     static DEFAULT_WEAVER_COMMAND = undefined;
     /**
-     *
-     * @returns {J#org.lara.interpreter.weaver.interf.WeaverEngine} the Java instance of the current WeaverEngine
+     * @returns The Java instance of the current WeaverEngine
      */
     static getWeaverEngine() {
         return JavaTypes.WeaverEngine.getThreadLocalWeaver();

--- a/LaraApi/src-lara/weaver/Weaver.js
+++ b/LaraApi/src-lara/weaver/Weaver.js
@@ -62,14 +62,14 @@ export default class Weaver {
             // Search for the default attribute in the joinpoint mappers
             for (const mapper of getJoinpointMappers()) {
                 if (mapper[joinPointType]) {
-                    return mapper[joinPointType]._defaultAttribute;
+                    return mapper[joinPointType]._defaultAttributeInfo.name;
                 }
             }
             // No wrapper was found, attempt to the collect information from the weaver
             return Weaver.getWeaverEngine().getDefaultAttribute(joinPointType);
         }
         else {
-            return joinPointType._defaultAttribute;
+            return joinPointType._defaultAttributeInfo.name;
         }
     }
     /**

--- a/LaraCommonLanguage/src-lara/weaver/jp/JoinPointsCommonPath.js
+++ b/LaraCommonLanguage/src-lara/weaver/jp/JoinPointsCommonPath.js
@@ -121,4 +121,10 @@ Check.isJoinPoint = function($jp, type, isOptional) {
 setUsingLaraCommonLanguage(true);
 setSelectorJoinPointsClass(LCLJoinPoints);
 clearJoinpointMappers();
-//registerJoinpointMapper(classesMapping);
+
+let mapper = {};
+for (const key in classesMapping) {
+  mapper[new classesMapping[key]().joinPointType] = classesMapping[key];
+}
+
+registerJoinpointMapper(mapper);

--- a/LaraCommonLanguageApi/src-lara/lcl/ml/Code2Vec.js
+++ b/LaraCommonLanguageApi/src-lara/lcl/ml/Code2Vec.js
@@ -6,7 +6,7 @@ class Code2Vec {
    * Collect information
    */
   printPaths() {
-    for (const desc of Query.search("file").search()) {
+    for (const desc of Query.search("file").search("joinpoint")) {
       if (!desc.hasChildren) {
         //for all the leafs of the tree
         this.#AST(desc.parent, [desc]);


### PR DESCRIPTION
Both `Query` and `Selector` APIs now accept wrapper classes as filters instead of strings.
Method variants that use strings to filter by joinpoint type have been tagged as deprecated and will be removed in the future.
Both APIs now report correct type information about their results.