### PR TITLE
Fix: restores behaviour of search using string as the type

### DIFF
--- a/Lara-JS/src-api/LaraJoinPoint.ts
+++ b/Lara-JS/src-api/LaraJoinPoint.ts
@@ -165,16 +165,16 @@ export function wrapJoinPoint(obj: any): any {
     );
   }
 
-  // Get join point type from name of the Java class, since getJoinPointType() might
+  // Get join point class from name of the Java class, since getJoinPointType() might
   // not always correspond to the actual join point class (e.g., anyweaver)
-  const jpType: string = obj.get_class();
+  const jpClass: string = obj.get_class();
 
   for (const mapper of JoinpointMappers) {
-    if (mapper[jpType]) {
-      return new mapper[jpType](obj);
+    if (mapper[jpClass]) {
+      return new mapper[jpClass](obj);
     }
   }
-  throw new Error("No mapper found for join point type: " + jpType);
+  throw new Error("No mapper found for join point type: " + jpClass);
 }
 
 export function unwrapJoinPoint(obj: any): any {

--- a/Lara-JS/src-api/LaraJoinPoint.ts
+++ b/Lara-JS/src-api/LaraJoinPoint.ts
@@ -165,7 +165,10 @@ export function wrapJoinPoint(obj: any): any {
     );
   }
 
-  const jpType: string = obj.getJoinPointType();
+  // Get join point type from name of the Java class, since getJoinPointType() might
+  // not always correspond to the actual join point class (e.g., anyweaver)
+  const jpType: string = obj.get_class();
+
   for (const mapper of JoinpointMappers) {
     if (mapper[jpType]) {
       return new mapper[jpType](obj);

--- a/Lara-JS/src-api/weaver/JoinPoints.ts
+++ b/Lara-JS/src-api/weaver/JoinPoints.ts
@@ -1,5 +1,6 @@
 import { LaraJoinPoint, wrapJoinPoint } from "../LaraJoinPoint.js";
 import Weaver from "./Weaver.js";
+import JpPredicate from "./predicate/JpPredicate.js";
 
 /**
  * Object which provides low-level join point-related methods.
@@ -70,9 +71,9 @@ export default class JoinPoints {
    *
    * @returns the nodes inside the scope of the given node.
    */
-  static scope<T extends typeof LaraJoinPoint>(
+  static scope(
     $jp: LaraJoinPoint,
-    jpType?: T
+    jpType?: JpPredicate
   ): LaraJoinPoint[] {
     return JoinPoints._getNodes(jpType, JoinPoints._all_scope_nodes($jp));
   }
@@ -81,9 +82,9 @@ export default class JoinPoints {
    *
    * @returns the children of the given node, according to the AST
    */
-  static children<T extends typeof LaraJoinPoint>(
+  static children(
     $jp: LaraJoinPoint,
-    jpType?: T
+    jpType?: JpPredicate
   ): LaraJoinPoint[] {
     return JoinPoints._getNodes(jpType, JoinPoints._all_children($jp));
   }
@@ -92,9 +93,9 @@ export default class JoinPoints {
    *
    * @returns the descendants of the given node, according to the AST, preorder traversal
    */
-  static descendants<T extends typeof LaraJoinPoint>(
+  static descendants(
     $jp: LaraJoinPoint,
-    jpType?: T
+    jpType?: JpPredicate
   ): LaraJoinPoint[] {
     return JoinPoints._getNodes(jpType, JoinPoints._all_descendants($jp));
   }
@@ -103,9 +104,9 @@ export default class JoinPoints {
    *
    * @returns the descendants of the given node, according to the AST, postorder traversal
    */
-  static descendantsPostorder<T extends typeof LaraJoinPoint>(
+  static descendantsPostorder(
     $jp: LaraJoinPoint,
-    jpType?: T
+    jpType?: JpPredicate
   ): LaraJoinPoint[] {
     return JoinPoints._getNodes(
       jpType,
@@ -117,8 +118,8 @@ export default class JoinPoints {
    *
    * @returns  the nodes related with the given node, according to the search function
    */
-  private static _getNodes<T extends typeof LaraJoinPoint>(
-    jpType?: T,
+  private static _getNodes(
+    jpType?: JpPredicate,
     $allJps: LaraJoinPoint[] = []
   ): LaraJoinPoint[] {
     // TODO: This function can be optimized by using streaming
@@ -126,7 +127,7 @@ export default class JoinPoints {
       return $allJps;
     }
 
-    return $allJps.filter((jp) => jp instanceof jpType);
+    return $allJps.filter((jp) => jpType.isInstance(jp));    
   }
 
   /**

--- a/Lara-JS/src-api/weaver/predicate/JpPredicate.ts
+++ b/Lara-JS/src-api/weaver/predicate/JpPredicate.ts
@@ -1,0 +1,21 @@
+import { LaraJoinPoint } from "../../LaraJoinPoint.js";
+
+export default abstract class JpPredicate {
+  
+    /**
+     * @returns the name of the join point
+     */
+    abstract jpName() : string;
+
+    /**
+     * @returns true if the underlying type is THE class LaraJoinPoint
+     */
+    abstract isLaraJoinPoint() : boolean;
+
+    abstract isInstance<T extends LaraJoinPoint>(jp: T):boolean
+}
+/*
+-> obter string com nome
+-> testar se é a classe LaraJoinPoint (LCL)
+-> Testar se um join point corresponde ao tipo
+*/

--- a/Lara-JS/src-api/weaver/predicate/JpPredicate.ts
+++ b/Lara-JS/src-api/weaver/predicate/JpPredicate.ts
@@ -12,10 +12,10 @@ export default abstract class JpPredicate {
      */
     abstract isLaraJoinPoint() : boolean;
 
+    /**
+     * 
+     * @param jp the join point we want to test
+     * @returns true if the join point is accepted by this predicate 
+     */
     abstract isInstance<T extends LaraJoinPoint>(jp: T):boolean
 }
-/*
--> obter string com nome
--> testar se é a classe LaraJoinPoint (LCL)
--> Testar se um join point corresponde ao tipo
-*/

--- a/Lara-JS/src-api/weaver/predicate/StringPredicate.ts
+++ b/Lara-JS/src-api/weaver/predicate/StringPredicate.ts
@@ -1,0 +1,22 @@
+import { LaraJoinPoint } from "../../LaraJoinPoint.js";
+import JpPredicate from "./JpPredicate.js";
+
+export default class StringPredicate extends JpPredicate {
+
+    constructor(private name: string) {
+        super();
+    }
+
+    jpName(): string {
+        return this.name;
+    }
+    isLaraJoinPoint(): boolean 
+    {
+        return false;
+    }
+
+    isInstance<T extends LaraJoinPoint>(jp: T): boolean {
+        return jp.instanceOf(this.name);
+    }
+
+}

--- a/Lara-JS/src-api/weaver/predicate/TypePredicate.ts
+++ b/Lara-JS/src-api/weaver/predicate/TypePredicate.ts
@@ -1,0 +1,22 @@
+import { LaraJoinPoint } from "../../LaraJoinPoint.js";
+import JpPredicate from "./JpPredicate.js";
+import Weaver from "../Weaver.js";
+
+export default class TypePredicate<T extends typeof LaraJoinPoint> extends JpPredicate {
+
+    constructor(private type: T) {
+        super();
+    }
+
+    jpName(): string {
+        return Weaver.findJoinpointTypeName(this.type) ?? "joinpoint"
+    }
+
+    isLaraJoinPoint(): boolean {
+        return this.type === LaraJoinPoint;
+    }
+    isInstance<T extends LaraJoinPoint>(jp: T): boolean {
+        return jp instanceof this.type;
+    }
+    
+}

--- a/LaraApi/src-java/pt/up/fe/specs/lara/LaraApiJsResource.java
+++ b/LaraApi/src-java/pt/up/fe/specs/lara/LaraApiJsResource.java
@@ -114,6 +114,9 @@ public enum LaraApiJsResource implements LaraResourceProvider {
     WEAVER_JS("weaver/Weaver.js"),
     WEAVERLAUNCHERBASE_JS("weaver/WeaverLauncherBase.js"),
     WEAVEROPTIONS_JS("weaver/WeaverOptions.js"),
+    JPPREDICATE_JS("weaver/predicate/JpPredicate.js"),
+    STRINGPREDICATE_JS("weaver/predicate/StringPredicate.js"),
+    TYPEPREDICATE_JS("weaver/predicate/TypePredicate.js"),
     ACTIONAWARECACHE_JS("weaver/util/ActionAwareCache.js"),
     WEAVERDATASTORE_JS("weaver/util/WeaverDataStore.js");
 

--- a/LaraApi/src-lara/LaraJoinPoint.js
+++ b/LaraApi/src-lara/LaraJoinPoint.js
@@ -95,7 +95,9 @@ export function wrapJoinPoint(obj) {
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `Given Java join point is a Java class but is not a JoinPoint: ${obj.getClass()}`);
     }
-    const jpType = obj.getJoinPointType();
+    // Get join point type from name of the Java class, since getJoinPointType() might
+    // not always correspond to the actual join point class (e.g., anyweaver)
+    const jpType = obj.get_class();
     for (const mapper of JoinpointMappers) {
         if (mapper[jpType]) {
             return new mapper[jpType](obj);

--- a/LaraApi/src-lara/LaraJoinPoint.js
+++ b/LaraApi/src-lara/LaraJoinPoint.js
@@ -95,15 +95,15 @@ export function wrapJoinPoint(obj) {
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `Given Java join point is a Java class but is not a JoinPoint: ${obj.getClass()}`);
     }
-    // Get join point type from name of the Java class, since getJoinPointType() might
+    // Get join point class from name of the Java class, since getJoinPointType() might
     // not always correspond to the actual join point class (e.g., anyweaver)
-    const jpType = obj.get_class();
+    const jpClass = obj.get_class();
     for (const mapper of JoinpointMappers) {
-        if (mapper[jpType]) {
-            return new mapper[jpType](obj);
+        if (mapper[jpClass]) {
+            return new mapper[jpClass](obj);
         }
     }
-    throw new Error("No mapper found for join point type: " + jpType);
+    throw new Error("No mapper found for join point type: " + jpClass);
 }
 export function unwrapJoinPoint(obj) {
     if (obj instanceof LaraJoinPoint) {

--- a/LaraApi/src-lara/weaver/JoinPoints.js
+++ b/LaraApi/src-lara/weaver/JoinPoints.js
@@ -90,7 +90,7 @@ export default class JoinPoints {
         if (jpType === undefined) {
             return $allJps;
         }
-        return $allJps.filter((jp) => jp instanceof jpType);
+        return $allJps.filter((jp) => jpType.isInstance(jp));
     }
     /**
      * Iterates of attributeNames, returns the first value that is not null or undefined.

--- a/LaraApi/src-lara/weaver/predicate/JpPredicate.js
+++ b/LaraApi/src-lara/weaver/predicate/JpPredicate.js
@@ -1,8 +1,3 @@
 export default class JpPredicate {
 }
-/*
--> obter string com nome
--> testar se é a classe LaraJoinPoint (LCL)
--> Testar se um join point corresponde ao tipo
-*/ 
 //# sourceMappingURL=JpPredicate.js.map

--- a/LaraApi/src-lara/weaver/predicate/JpPredicate.js
+++ b/LaraApi/src-lara/weaver/predicate/JpPredicate.js
@@ -1,0 +1,8 @@
+export default class JpPredicate {
+}
+/*
+-> obter string com nome
+-> testar se é a classe LaraJoinPoint (LCL)
+-> Testar se um join point corresponde ao tipo
+*/ 
+//# sourceMappingURL=JpPredicate.js.map

--- a/LaraApi/src-lara/weaver/predicate/StringPredicate.js
+++ b/LaraApi/src-lara/weaver/predicate/StringPredicate.js
@@ -1,0 +1,18 @@
+import JpPredicate from "./JpPredicate.js";
+export default class StringPredicate extends JpPredicate {
+    name;
+    constructor(name) {
+        super();
+        this.name = name;
+    }
+    jpName() {
+        return this.name;
+    }
+    isLaraJoinPoint() {
+        return false;
+    }
+    isInstance(jp) {
+        return jp.instanceOf(this.name);
+    }
+}
+//# sourceMappingURL=StringPredicate.js.map

--- a/LaraApi/src-lara/weaver/predicate/TypePredicate.js
+++ b/LaraApi/src-lara/weaver/predicate/TypePredicate.js
@@ -1,0 +1,20 @@
+import { LaraJoinPoint } from "../../LaraJoinPoint.js";
+import JpPredicate from "./JpPredicate.js";
+import Weaver from "../Weaver.js";
+export default class TypePredicate extends JpPredicate {
+    type;
+    constructor(type) {
+        super();
+        this.type = type;
+    }
+    jpName() {
+        return Weaver.findJoinpointTypeName(this.type) ?? "joinpoint";
+    }
+    isLaraJoinPoint() {
+        return this.type === LaraJoinPoint;
+    }
+    isInstance(jp) {
+        return jp instanceof this.type;
+    }
+}
+//# sourceMappingURL=TypePredicate.js.map


### PR DESCRIPTION
Search using a string to identify the type of join point should now have the same behavior as before the introduction of search with join point classes.