### PR TITLE
JoinPointMapper fix

### DIFF
--- a/Lara-JS/scripts/build-LaraJoinPoint.js
+++ b/Lara-JS/scripts/build-LaraJoinPoint.js
@@ -232,7 +232,9 @@ export function registerJoinpointMapperFunction(
   }
 
   const jpType: string = obj.getJoinPointType();
-  for (const mapper of JoinpointMappers) {
+  // Iterate in reverse order, to give priority to most recently added mappers
+  for(let i = JoinpointMappers.length - 1; i>=0; i--) {
+    const mapper = JoinpointMappers[i];  
     const laraJp = mapper.toJpInstance(jpType, obj);
     if (laraJp) {
       return laraJp;

--- a/Lara-JS/src-api/LaraJoinPoint.ts
+++ b/Lara-JS/src-api/LaraJoinPoint.ts
@@ -283,7 +283,9 @@ export function wrapJoinPoint(obj: any): any {
   }
 
   const jpType: string = obj.getJoinPointType();
-  for (const mapper of JoinpointMappers) {
+  // Iterate in reverse order, to give priority to most recently added mappers
+  for (let i = JoinpointMappers.length - 1; i >= 0; i--) {
+    const mapper = JoinpointMappers[i];
     const laraJp = mapper.toJpInstance(jpType, obj);
     if (laraJp) {
       return laraJp;


### PR DESCRIPTION
Makes LaraJoinPoint.wrapJoinPoint() iterate mappers in reverse order, to prioritize most recently added mappers